### PR TITLE
add --max-retry argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,26 @@ To download a single file or album without the UI, you can use this command:
 python3 downloader.py <bunkr_url> --disable-ui
 ```
 
+## Maximum number of retries
+
+When the downloading failed, by default there is 5 retry attempts to download each media file again.
+You can control the number of maximum attempts with the `--max-retry` argument.
+It may be useful when you would like to skip broken media faster for the very large media collection.
+
+### Usage
+
+Allowed values: 0 (don't re-download) and larger.
+
+```bash
+python3 downloader.py <bunkr_url> --max-retry 1
+```
+
+### Example:
+
+```bash
+python3 downloader.py https://bunkr.si/a/PUK068QE --max-retry 1
+```
+
 ## Logging
 
 The application logs any issues encountered during the download process in a file named `session_log.txt`. Check this file for any URLs that may have been blocked or had errors.

--- a/downloader.py
+++ b/downloader.py
@@ -55,6 +55,7 @@ async def handle_download_process(
     url: str,
     initial_soup: BeautifulSoup,
     live_manager: LiveManager,
+    max_retry: int,
 ) -> None:
     """Handle the download process for a Bunkr album or a single item."""
     host_page = get_host_page(url)
@@ -68,7 +69,7 @@ async def handle_download_process(
             album_info=AlbumInfo(album_id=identifier, item_pages=item_pages),
             live_manager=live_manager,
         )
-        await album_downloader.download_album()
+        await album_downloader.download_album(max_retry=max_retry)
 
     # Single item download
     else:
@@ -115,7 +116,7 @@ async def validate_and_download(
     )
 
     try:
-        await handle_download_process(session_info, url, soup, live_manager)
+        await handle_download_process(session_info, url, soup, live_manager, args.max_retry)
 
     except (RequestConnectionError, Timeout, RequestException) as err:
         error_message = f"Error downloading from {url}: {err}"

--- a/src/config.py
+++ b/src/config.py
@@ -75,6 +75,7 @@ LOG_MANAGER_CONFIG = {
 # ============================
 MAX_FILENAME_LEN = 120  # The maximum length for a file name.
 MAX_WORKERS = 3         # The maximum number of threads for concurrent downloads.
+MAX_RETRY = 5           # The maximum number of retries for downloading a single media.
 
 # Mapping of URL identifiers to a boolean for album (True) vs single file (False).
 URL_TYPE_MAPPING = {"a": True, "f": False, "i": False, "v": False}
@@ -190,6 +191,12 @@ def add_common_arguments(parser: ArgumentParser) -> None:
         "--disable-disk-check",
         action="store_true",
         help="Disable the disk space check for available free space.",
+    )
+    parser.add_argument(
+        "--max-retry",
+        type=int,
+        default=MAX_RETRY,
+        help="Maximum number of retries for downloading a single media."
     )
 
 

--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -7,7 +7,7 @@ integrating with live task displays.
 import asyncio
 from asyncio import Semaphore
 
-from src.config import MAX_WORKERS, AlbumInfo, DownloadInfo, SessionInfo
+from src.config import MAX_WORKERS, MAX_RETRY, AlbumInfo, DownloadInfo, SessionInfo
 from src.crawlers.crawler_utils import get_download_info
 from src.general_utils import fetch_page
 from src.managers.live_manager import LiveManager
@@ -35,6 +35,7 @@ class AlbumDownloader:
         item_page: str,
         current_task: int,
         semaphore: Semaphore,
+        max_retry: int,
     ) -> None:
         """Handle the download of an individual item in the album."""
         async with semaphore:
@@ -63,13 +64,14 @@ class AlbumDownloader:
                         task=task,
                     ),
                     live_manager=self.live_manager,
+                    retries=max_retry,
                 )
 
                 failed_download = await asyncio.to_thread(media_downloader.download)
                 if failed_download:
                     self.failed_downloads.append(failed_download)
 
-    async def download_album(self, max_workers: int = MAX_WORKERS) -> None:
+    async def download_album(self, max_workers: int = MAX_WORKERS, max_retry: int = MAX_RETRY) -> None:
         """Handle the album download."""
         num_tasks = len(self.album_info.item_pages)
         self.live_manager.add_overall_task(
@@ -80,7 +82,7 @@ class AlbumDownloader:
         # Create tasks for downloading each item in the album
         semaphore = asyncio.Semaphore(max_workers)
         tasks = [
-            self.execute_item_download(item_page, current_task, semaphore)
+            self.execute_item_download(item_page, current_task, semaphore, max_retry)
             for current_task, item_page in enumerate(self.album_info.item_pages)
         ]
         await asyncio.gather(*tasks)

--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -20,6 +20,7 @@ from src.config import (
     DownloadInfo,
     HTTPStatus,
     SessionInfo,
+    MAX_RETRY,
 )
 from src.file_utils import truncate_filename, write_on_session_log
 
@@ -37,7 +38,7 @@ class MediaDownloader:
         session_info: SessionInfo,
         download_info: DownloadInfo,
         live_manager: LiveManager,
-        retries: int = 5,
+        retries: int = MAX_RETRY,
     ) -> None:
         """Initialize the MediaDownloader instance."""
         self.session_info = session_info


### PR DESCRIPTION
When the downloading failed, by default there is 5 retry attempts to download each media file again. You can control the number of maximum attempts with the `--max-retry` argument. It may be useful when you would like to skip broken media faster for the very large media collection.