### PR TITLE
Implement task reasons for task result summary

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -177,6 +177,23 @@ class TaskResult(IntEnum):
     FAILED = 2    # The task failed due to an error.
     SKIPPED = 3   # The task was intentionally skipped.
 
+class TaskReason(IntEnum):
+    """Enumerate the possible reasons per each task result."""
+    
+    REASONS_ALL = -1              # The total count of tasks per any group
+    
+    class CompletedReason(IntEnum):
+        DOWNLOAD_SUCCESS = 1
+
+    class FailedReason(IntEnum):
+        MAX_RETRIES_REACHED = 1
+
+    class SkippedReason(IntEnum):
+        ALREADY_DOWNLOADED = 1
+        IGNORE_LIST = 2
+        INCLUDE_LIST_NO_MATCH = 3
+        DOMAIN_OFFLINE = 4
+
 # ============================
 # Argument Parsing
 # ============================

--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -22,6 +22,7 @@ from src.config import (
     HTTPStatus,
     SessionInfo,
     TaskResult,
+    TaskReason,
 )
 from src.file_utils import truncate_filename, write_on_session_log
 
@@ -93,7 +94,7 @@ class MediaDownloader:
             )
             write_on_session_log(self.download_info.download_link)
             self.live_manager.update_task(self.download_info.task, visible=False)
-            self.live_manager.update_result(TaskResult.FAILED)
+            self.live_manager.update_result.add_skipped(TaskReason.SkippedReason.DOMAIN_OFFLINE)
             return None
 
         formatted_filename = truncate_filename(self.download_info.filename)
@@ -118,7 +119,7 @@ class MediaDownloader:
         if failed_download:
             return self._handle_failed_download(is_final_attempt=is_final_attempt)
 
-        self.live_manager.update_result(TaskResult.COMPLETED)
+        self.live_manager.update_result.add_completed(TaskReason.CompletedReason.DOWNLOAD_SUCCESS)
         return None
 
     # Private methods
@@ -144,11 +145,11 @@ class MediaDownloader:
                 completed=100,
                 visible=False,
             )
-            self.live_manager.update_result(TaskResult.SKIPPED)
             return True
 
         # Check if the file already exists
         if Path(final_path).exists():
+            self.live_manager.update_result.add_skipped(TaskReason.SkippedReason.ALREADY_DOWNLOADED)
             return log_and_skip_event(
                 f"{self.download_info.filename} has already been downloaded.",
             )
@@ -157,6 +158,7 @@ class MediaDownloader:
         if ignore_list and any(
             word in self.download_info.filename for word in ignore_list
         ):
+            self.live_manager.update_result.add_skipped(TaskReason.SkippedReason.IGNORE_LIST)
             return log_and_skip_event(
                 f"{self.download_info.filename} matches the ignore list.",
             )
@@ -165,6 +167,7 @@ class MediaDownloader:
         if include_list and all(
             word not in self.download_info.filename for word in include_list
         ):
+            self.live_manager.update_result.add_skipped(TaskReason.SkippedReason.INCLUDE_LIST_NO_MATCH)
             return log_and_skip_event(
                 f"No included words found for {self.download_info.filename}.",
             )
@@ -174,6 +177,7 @@ class MediaDownloader:
             self.download_info.download_link, self.session_info.bunkr_status,
         ):
             write_on_session_log(self.download_info.download_link)
+            self.live_manager.update_result.add_skipped(TaskReason.SkippedReason.DOMAIN_OFFLINE)
             return log_and_skip_event(
                 f"The subdomain for {self.download_info.download_link} has been "
                 "previously marked as offline.",
@@ -257,5 +261,5 @@ class MediaDownloader:
             "Check the log file.",
         )
         self.live_manager.update_task(self.download_info.task, visible=False)
-        self.live_manager.update_result(TaskResult.FAILED)
+        self.live_manager.update_result.add_failed(TaskReason.FailedReason.MAX_RETRIES_REACHED)
         return None


### PR DESCRIPTION
Fix for https://github.com/Lysagxra/BunkrDownloader/issues/41

Separate methods are provided to bind each TaskResult to the corresponding TaskReason.
To miniminze the final output in console, only items with non-zero records are printed.
Also, TaskReason having only 1 enum not printed too.

<img width="1592" height="261" alt="image" src="https://github.com/user-attachments/assets/0acd195d-be17-4998-80de-ea0cf573ae65" />
