### PR TITLE
Fix UnboundLocalError: local variable 'fixed_album_name' referenced before assignment in url_utils.py

### DIFF
--- a/src/url_utils.py
+++ b/src/url_utils.py
@@ -150,6 +150,8 @@ def get_album_name(soup: BeautifulSoup) -> str | None:
     raw_album_name = name_container.find("h1").get_text(strip=True)
     unescaped_album_name = html.unescape(raw_album_name)
 
+    fixed_album_name = unescaped_album_name
+
     # Attempt to fix mojibake (UTF-8 bytes mis-decoded as Latin-1). If encoding/decoding
     # fails, keep the decoded version
     with contextlib.suppress(UnicodeEncodeError, UnicodeDecodeError):


### PR DESCRIPTION
I encountered UnboundLocalError while running the downloader to download an album. The issue occurred in src/url_utils.py, within the get_album_name function. To fix it, I Initialized fixed_album_name with a default value (the original unescaped_album_name) before entering the contextlib.suppress block.
Traceback:
```text
File "...\BunkrDownloader\src\url_utils.py", line 159, in get_album_name
    if fixed_album_name != unescaped_album_name:
       ^^^^^^^^^^^^^^^^
UnboundLocalError: cannot access local variable 'fixed_album_name' where it is not associated with a value
```