### PR TITLE
fix(album_downloader): correct missing f-prefix on RuntimeError message string

### DIFF
--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -48,7 +48,7 @@ class AlbumDownloader:
                     event="Fetch failed",
                     details=f"Unable to load album item page: {item_page}",
                 )
-                error_message = "Failed to load album item page: {item_page}"
+                error_message = f"Failed to load album item page: {item_page}"
                 raise RuntimeError(error_message)
 
             item_download_link, item_filename = await get_download_info(


### PR DESCRIPTION
## Summary

Line 51 of `execute_item_download` in `src/downloaders/album_downloader.py`
constructed the `RuntimeError` message as a plain string literal, leaving the
`{item_page}` brace expression un-interpolated. The exception was raised with
the text `'{item_page}'` verbatim instead of the actual URL, masking the true
failing page in tracebacks.

## Change

```python
# Before
error_message = "Failed to load album item page: {item_page}"

# After
error_message = f"Failed to load album item page: {item_page}"
```

## Impact

- The `update_log` call immediately above already used the correct f-string;
  this aligns the exception message to the same standard.
- No other logic, retry paths, semaphore bounding, or resource reclamation
  was altered.
- Superset audit passed — zero regressions.