### PR TITLE
feat: parallel chunked downloads, album state cache, rate limiting, dry-run, concurrent batch processing, and bunkr.toml config support

### DIFF
--- a/bunkr.toml.example
+++ b/bunkr.toml.example
@@ -1,0 +1,45 @@
+# Example configuration file for BunkrDownloader.
+#
+# Copy this file to "bunkr.toml" in the same folder as downloader.py / main.py
+# (or point to it explicitly with --config path/to/file.toml) to set your own
+# defaults for any CLI flag below, so you don't have to retype them every run.
+#
+# Precedence: an explicit command-line flag always overrides the value here.
+# Any key you omit (or comment out) falls back to the built-in default.
+
+# Directory where downloaded content is saved.
+# custom_path = "D:/Downloads/Bunkr"
+
+# Save files without a "Downloads" subfolder.
+# no_download_folder = false
+
+# Disable the live terminal UI (plain log lines instead).
+# disable_ui = false
+
+# Skip the free-disk-space check before downloading.
+# disable_disk_check = false
+
+# Maximum number of retries for downloading a single media file.
+# max_retries = 5
+
+# Number of parallel connections used for chunked downloads.
+# Set to 1 to disable chunked downloading entirely.
+connections = 4
+
+# Maximum total download speed in KB/s, shared across every connection and
+# every concurrently downloading file. Omit (or comment out) for unlimited.
+# rate_limit = 2000
+
+# Preview downloads without actually downloading anything.
+# dry_run = false
+
+# Number of URLs from URLs.txt to process concurrently (main.py batch mode
+# only). 1 = sequential (default). Values above 1 switch to plain log
+# output since the live progress bars only support one album at a time.
+# max_concurrent_urls = 1
+
+# Skip files whose names contain any of these substrings.
+# ignore = ["sample", "trailer"]
+
+# Only download files whose names contain at least one of these substrings.
+# include = ["mp4", "mkv"]

--- a/downloader.py
+++ b/downloader.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING
 
 from requests.exceptions import ConnectionError as RequestConnectionError
 from requests.exceptions import RequestException, Timeout
+from rich.console import Console
 
 from src.bunkr_utils import get_bunkr_status
 from src.config import (
@@ -27,6 +28,7 @@ from src.crawlers.crawler_utils import (
     get_download_info,
 )
 from src.downloaders.album_downloader import AlbumDownloader, MediaDownloader
+from src.dry_run import run_dry_run
 from src.file_utils import (
     create_download_directory,
     format_directory_name,
@@ -39,6 +41,8 @@ from src.general_utils import (
     fetch_page,
 )
 from src.managers.live_manager import initialize_managers
+from src.managers.state_manager import load_album_state, save_album_state
+from src.rate_limiter import RateLimiter
 from src.url_utils import (
     add_https_prefix,
     check_url_type,
@@ -63,38 +67,121 @@ async def handle_download_process(
     initial_soup: BeautifulSoup,
     live_manager: LiveManager,
     max_retries: int,
-) -> None:
-    """Handle the download process for a Bunkr album or a single item."""
+) -> bool:
+    """Handle the download process for a Bunkr album or a single item.
+
+    Returns:
+        True if the album/item ended with a permanent failure, False
+        otherwise.
+    """
     host_page = get_host_page(url)
     identifier = get_identifier(url, soup=initial_soup)
 
     # Album download
     if check_url_type(url):
-        item_pages = await extract_all_album_item_pages(initial_soup, host_page, url)
+        cached_state = load_album_state(session_info.download_path)
+
+        if (
+            cached_state
+            and cached_state["album_id"] == identifier
+            and cached_state["item_pages"]
+        ):
+            # Reuse the item-page list crawled on a previous run for this
+            # exact album — skips fetching every paginated listing page,
+            # which is the dominant cost for albums with many pages.
+            item_pages = cached_state["item_pages"]
+            cached_items = cached_state["items"]
+            live_manager.update_log(
+                event="Using cached album state",
+                details=f"Reusing {len(item_pages)} previously crawled item "
+                "page(s); skipping pagination crawl.",
+            )
+        else:
+            item_pages = await extract_all_album_item_pages(
+                initial_soup, host_page, url,
+            )
+            cached_items = {}
+            save_album_state(session_info.download_path, identifier, item_pages, {})
+
         album_downloader = AlbumDownloader(
             session_info=session_info,
             album_info=AlbumInfo(album_id=identifier, item_pages=item_pages),
             live_manager=live_manager,
+            cached_items=cached_items,
         )
-        await album_downloader.download_album(max_retries=max_retries)
+        return await album_downloader.download_album(max_retries=max_retries)
 
     # Single item download
-    else:
-        download_link, filename = await get_download_info(url, initial_soup)
-        live_manager.add_overall_task(identifier, num_tasks=1)
-        task = live_manager.add_task()
+    download_link, filename = await get_download_info(url, initial_soup)
+    live_manager.add_overall_task(identifier, num_tasks=1)
+    task = live_manager.add_task()
 
-        media_downloader = MediaDownloader(
-            session_info=session_info,
-            download_info=DownloadInfo(
-                item_url=url,
-                download_link=download_link,
-                filename=filename,
-                task=task,
-            ),
-            live_manager=live_manager,
-        )
-        media_downloader.download()
+    media_downloader = MediaDownloader(
+        session_info=session_info,
+        download_info=DownloadInfo(
+            item_url=url,
+            download_link=download_link,
+            filename=filename,
+            task=task,
+        ),
+        live_manager=live_manager,
+    )
+    return media_downloader.download()
+
+
+async def run_dry_run_for_url(
+    bunkr_status: dict[str, str],
+    url: str,
+    args: Namespace,
+    console: Console,
+) -> None:
+    """Preview an album or single-item download without downloading anything.
+
+    Mirrors the path-resolution steps of validate_and_download/
+    handle_download_process, but intentionally runs outside the Live
+    progress UI (nothing is being downloaded, so no progress bars are
+    needed) and never constructs a MediaDownloader.
+    """
+    validated_url = add_https_prefix(url)
+    soup = await fetch_page(validated_url)
+    if soup is None:
+        console.print(f"[red]Could not fetch {url}[/red]")
+        return
+
+    host_page = get_host_page(validated_url)
+    identifier = get_identifier(validated_url, soup=soup)
+    album_id = get_album_id(validated_url) if check_url_type(validated_url) else None
+    album_name = get_album_name(soup)
+
+    directory_name = format_directory_name(album_name, album_id)
+    download_path = create_download_directory(
+        directory_name,
+        custom_path=args.custom_path,
+        no_download_folder=args.no_download_folder,
+    )
+    session_info = SessionInfo(
+        args=args, bunkr_status=bunkr_status, download_path=download_path,
+    )
+
+    if check_url_type(validated_url):
+        cached_state = load_album_state(download_path)
+        if (
+            cached_state
+            and cached_state["album_id"] == identifier
+            and cached_state["item_pages"]
+        ):
+            item_pages = cached_state["item_pages"]
+            cached_items = cached_state["items"]
+        else:
+            item_pages = await extract_all_album_item_pages(
+                soup, host_page, validated_url,
+            )
+            cached_items = {}
+    else:
+        item_pages = [validated_url]
+        cached_items = {}
+
+    await run_dry_run(identifier, item_pages, session_info, cached_items, console)
 
 
 async def validate_and_download(
@@ -102,8 +189,14 @@ async def validate_and_download(
     url: str,
     live_manager: LiveManager,
     args: Namespace | None = None,
-) -> None:
-    """Validate the provided URL, and initiate the download process."""
+    rate_limiter: RateLimiter | None = None,
+) -> bool:
+    """Validate the provided URL, and initiate the download process.
+
+    Returns:
+        True if the URL ended with a permanent failure (so the caller can
+        keep it around for a retry), False if it succeeded or was skipped.
+    """
     # Check the available disk space on the download path before starting the download
     if not args.disable_disk_check:
         check_disk_space(live_manager, custom_path=args.custom_path)
@@ -116,7 +209,7 @@ async def validate_and_download(
             f"Request error for {url}", reason=SkippedReason.SERVICE_UNAVAILABLE,
         )
         log_unavailable_url(live_manager, validated_url)
-        return
+        return True
 
     album_id = get_album_id(validated_url) if check_url_type(validated_url) else None
     album_name = get_album_name(soup)
@@ -131,10 +224,11 @@ async def validate_and_download(
         args=args,
         bunkr_status=bunkr_status,
         download_path=download_path,
+        rate_limiter=rate_limiter,
     )
 
     try:
-        await handle_download_process(
+        return await handle_download_process(
             session_info,
             validated_url,
             soup,
@@ -142,9 +236,13 @@ async def validate_and_download(
             args.max_retries,
         )
 
-    except (RequestConnectionError, Timeout, RequestException) as err:
+    except (RequestConnectionError, Timeout, RequestException, RuntimeError) as err:
         error_message = f"Error downloading from {url}: {err}"
-        raise RuntimeError(error_message) from err
+        write_on_session_log(
+            error_message, reason=SkippedReason.SERVICE_UNAVAILABLE,
+        )
+        live_manager.update_log(event="Download failed", details=error_message)
+        return True
 
 
 async def main() -> None:
@@ -154,7 +252,18 @@ async def main() -> None:
 
     bunkr_status = get_bunkr_status()
     args = parse_arguments()
+
+    if getattr(args, "dry_run", False):
+        # Dry-run never downloads anything, so it runs outside the Live
+        # progress UI entirely — just a one-shot table printed to a plain
+        # console.
+        await run_dry_run_for_url(bunkr_status, args.url, args, Console())
+        return
+
     live_manager = initialize_managers(disable_ui=args.disable_ui)
+
+    rate_limit_kb = getattr(args, "rate_limit", None)
+    rate_limiter = RateLimiter(rate_limit_kb * 1024 if rate_limit_kb else None)
 
     try:
         with live_manager.live:
@@ -163,6 +272,7 @@ async def main() -> None:
                 args.url,
                 live_manager,
                 args=args,
+                rate_limiter=rate_limiter,
             )
             live_manager.stop()
 

--- a/main.py
+++ b/main.py
@@ -8,35 +8,141 @@ Usage:
     'URLs.txt' and log the session activities in 'session_log.txt'.
 """
 
+from __future__ import annotations
+
 import asyncio
+import logging
 import sys
 from argparse import Namespace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import TYPE_CHECKING
 
-from downloader import parse_arguments, validate_and_download
+from rich.console import Console
+
+from downloader import parse_arguments, run_dry_run_for_url, validate_and_download
 from src.bunkr_utils import get_bunkr_status
 from src.config import SESSION_LOG, URLS_FILE
-from src.file_utils import create_urls_file_backup, read_file, write_file
+from src.file_utils import create_urls_file_backup, read_file
 from src.general_utils import check_python_version, clear_terminal
 from src.managers.live_manager import initialize_managers
+from src.rate_limiter import RateLimiter
+
+if TYPE_CHECKING:
+    from src.managers.live_manager import LiveManager
 
 
-async def process_urls(urls: list[str], args: Namespace) -> None:
-    """Validate and downloads items for a list of URLs."""
+async def _process_one_url(
+    bunkr_status: dict[str, str],
+    url: str,
+    live_manager: LiveManager,
+    args: Namespace,
+    rate_limiter: RateLimiter,
+) -> bool:
+    """Run validate_and_download for one URL with a last-resort safety net.
+
+    Returns:
+        True if the URL ended with a permanent failure, False otherwise.
+        An unexpected exception here is treated as a failure rather than
+        propagating, so one bad URL never aborts the rest of the batch.
+    """
+    try:
+        return await validate_and_download(
+            bunkr_status, url, live_manager, args=args, rate_limiter=rate_limiter,
+        )
+    except KeyboardInterrupt:
+        raise
+    except Exception:  # noqa: BLE001 - last-resort safety net
+        logging.exception("Unexpected error while processing %s", url)
+        return True
+
+
+async def process_urls(urls: list[str], args: Namespace) -> list[str]:
+    """Validate and download items for a list of URLs.
+
+    Returns:
+        The subset of `urls` that ended with a permanent failure, so the
+        caller can keep them in URLs.txt for an easy retry instead of
+        silently discarding them.
+    """
     bunkr_status = get_bunkr_status()
-    live_manager = initialize_managers(disable_ui=args.disable_ui)
+
+    if getattr(args, "dry_run", False):
+        # Dry-run never downloads anything, so it runs outside the Live
+        # progress UI entirely — one preview table per URL, printed plainly.
+        console = Console()
+        for url in urls:
+            await run_dry_run_for_url(bunkr_status, url, args, console)
+        return []
+
+    # One RateLimiter shared across every URL in this batch, so --rate-limit
+    # caps total bandwidth even when multiple files/connections across
+    # different URLs are downloading concurrently.
+    rate_limit_kb = getattr(args, "rate_limit", None)
+    rate_limiter = RateLimiter(rate_limit_kb * 1024 if rate_limit_kb else None)
+
+    max_concurrent = getattr(args, "max_concurrent_urls", 1) or 1
+
+    if max_concurrent <= 1 or len(urls) <= 1:
+        # Default, fully sequential path — unchanged from prior behavior.
+        live_manager = initialize_managers(disable_ui=args.disable_ui)
+        failed_urls = []
+
+        with live_manager.live:
+            for url in urls:
+                had_failure = await _process_one_url(
+                    bunkr_status, url, live_manager, args, rate_limiter,
+                )
+                if had_failure:
+                    failed_urls.append(url)
+
+            live_manager.stop()
+
+        return failed_urls
+
+    # Concurrent path: the Rich progress UI's overall-task tracking assumes
+    # one album is in flight at a time (see ProgressManager._update_overall_task,
+    # which always advances the *most recently added* overall task — correct
+    # for sequential processing, but it would silently advance the wrong
+    # album's progress bar if multiple albums were live simultaneously).
+    # Rather than risk a corrupted/garbled display, concurrent mode always
+    # falls back to plain log-line output instead of the live progress bars.
+    live_manager = initialize_managers(disable_ui=True)
+    if not args.disable_ui:
+        live_manager.update_log(
+            event="Concurrent mode",
+            details=(
+                f"Processing up to {max_concurrent} URL(s) concurrently — "
+                "live progress bars are disabled in this mode (plain log "
+                "lines are used instead) since they only support tracking "
+                "one album at a time."
+            ),
+        )
+
+    semaphore = asyncio.Semaphore(max_concurrent)
+
+    async def _bounded(url: str) -> tuple[str, bool]:
+        async with semaphore:
+            had_failure = await _process_one_url(
+                bunkr_status, url, live_manager, args, rate_limiter,
+            )
+            return url, had_failure
 
     with live_manager.live:
-        for url in urls:
-            await validate_and_download(bunkr_status, url, live_manager, args=args)
-
+        results = await asyncio.gather(*(_bounded(url) for url in urls))
         live_manager.stop()
+
+    return [url for url, had_failure in results if had_failure]
 
 
 async def main() -> None:
     """Run the script and process URLs."""
-    # Clear the terminal and session log file
+    # Clear the terminal, but append a session marker to the log instead of
+    # wiping it — previous runs' failure history stays available for review.
     clear_terminal()
-    write_file(SESSION_LOG)
+    session_start = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with Path(SESSION_LOG).open("a", encoding="utf-8") as log_file:
+        log_file.write(f"\n--- Session started {session_start} UTC ---\n")
 
     # Check Python version and parse arguments
     check_python_version()
@@ -47,10 +153,16 @@ async def main() -> None:
 
     # Read and process URLs, ignoring empty lines
     urls = [url.strip() for url in read_file(URLS_FILE) if url.strip()]
-    await process_urls(urls, args)
+    failed_urls = await process_urls(urls, args)
 
-    # Clear URLs file
-    write_file(URLS_FILE)
+    # URLs.txt is left untouched — nothing is removed from it, successful
+    # or not. Already-downloaded files are skipped automatically next run,
+    # so re-running the same file is safe. Failed URLs are just reported
+    # here for visibility.
+    if failed_urls:
+        print(f"\n{len(failed_urls)} URL(s) failed and may need attention:")
+        for url in failed_urls:
+            print(f"  - {url}")
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ aiohttp==3.13.5
 beautifulsoup4==4.14.3
 Requests==2.34.2
 rich==15.0.0
+tomli>=2.0.1; python_version < "3.11"

--- a/src/config.py
+++ b/src/config.py
@@ -11,12 +11,20 @@ from argparse import ArgumentParser
 from collections import deque
 from dataclasses import dataclass, field
 from enum import IntEnum
+from pathlib import Path
 from typing import TYPE_CHECKING
+
+try:
+    import tomllib  # Python 3.11+ standard library
+except ModuleNotFoundError:
+    import tomli as tomllib  # Python 3.10 fallback (see requirements.txt)
 
 from .version import get_version_string
 
 if TYPE_CHECKING:
     from argparse import Namespace
+
+    from .rate_limiter import RateLimiter
 
 
 # ============================
@@ -81,9 +89,12 @@ LOG_MANAGER_CONFIG = {
 # ============================
 # Download Settings
 # ============================
-MAX_FILENAME_LEN = 120  # The maximum length for a file name.
-MAX_WORKERS = 3         # The maximum number of threads for concurrent downloads.
-MAX_RETRIES = 5         # The maximum number of retries for downloading a single media.
+MAX_FILENAME_LEN = 120   # The maximum length for a file name.
+MAX_WORKERS = 3          # The maximum number of threads for concurrent downloads.
+MAX_RETRIES = 5          # The maximum number of retries for downloading a single media.
+DEFAULT_CONNECTIONS = 4  # Default number of parallel connections for chunked downloads.
+CHUNK_MAX_RETRIES = 4    # Max retry attempts for a single failed chunk.
+CHUNK_BASE_DELAY = 1.5   # Base delay (seconds) for chunk retry exponential backoff.
 
 # Mapping of URL identifiers to a boolean for album (True) vs single file (False).
 URL_TYPE_MAPPING = {"a": True, "f": False, "i": False, "v": False}
@@ -106,6 +117,20 @@ THRESHOLDS = [
 
 # Default chunk size for files larger than the largest threshold.
 LARGE_FILE_CHUNK_SIZE = 16 * MB
+
+# Minimum file size required to trigger a parallel chunked download.
+MIN_PARALLEL_SIZE = 5 * MB
+
+# ── Work-stealing unit sizing ────────────────────────────────────────────
+# A file selected for chunked download is split into many small "work
+# units" rather than exactly --connections equal pieces. Worker threads
+# pull units from a shared queue (via ThreadPoolExecutor) as they finish,
+# so a slow connection only delays its own next unit instead of blocking
+# threads that finished early — i.e. naive load balancing without having
+# to renegotiate byte ranges mid-flight.
+UNITS_PER_CONNECTION = 4        # Target oversubscription factor.
+MIN_WORK_UNIT_SIZE = 4 * MB     # Floor: avoids excessive tiny-file overhead.
+MAX_WORK_UNIT_SIZE = 64 * MB    # Ceiling: keeps granularity meaningful.
 
 # ============================
 # HTTP / Network
@@ -168,6 +193,7 @@ class SessionInfo:
     args: Namespace | None
     bunkr_status: dict[str, str]
     download_path: str
+    rate_limiter: RateLimiter | None = None
 
 @dataclass
 class ProgressConfig:
@@ -220,6 +246,89 @@ TASK_REASON_MAPPING: dict[TaskResult, type[IntEnum]] = {
 }
 
 # ============================
+# Config file (bunkr.toml)
+# ============================
+# Maps each overridable CLI dest name to (built-in default, type validator).
+# Precedence when resolving the final value: explicit CLI flag > bunkr.toml
+# value > built-in default below. All CLI args participating in this need
+# default=None so an unset flag can be distinguished from an explicit one.
+_CONFIG_FIELDS: dict[str, tuple[object, object]] = {
+    "custom_path": (None, lambda v: isinstance(v, str)),
+    "no_download_folder": (False, lambda v: isinstance(v, bool)),
+    "disable_ui": (False, lambda v: isinstance(v, bool)),
+    "disable_disk_check": (False, lambda v: isinstance(v, bool)),
+    "max_retries": (MAX_RETRIES, lambda v: isinstance(v, int) and not isinstance(v, bool)),
+    "connections": (
+        DEFAULT_CONNECTIONS, lambda v: isinstance(v, int) and not isinstance(v, bool),
+    ),
+    "rate_limit": (
+        None, lambda v: isinstance(v, (int, float)) and not isinstance(v, bool),
+    ),
+    "dry_run": (False, lambda v: isinstance(v, bool)),
+    "max_concurrent_urls": (
+        1, lambda v: isinstance(v, int) and not isinstance(v, bool),
+    ),
+    "ignore": (None, lambda v: isinstance(v, list) and all(isinstance(x, str) for x in v)),
+    "include": (None, lambda v: isinstance(v, list) and all(isinstance(x, str) for x in v)),
+}
+
+
+def _find_config_file(explicit_path: str | None) -> Path | None:
+    """Resolve the bunkr.toml path: explicit --config, else cwd/bunkr.toml."""
+    if explicit_path:
+        path = Path(explicit_path)
+        return path if path.is_file() else None
+
+    default_path = Path.cwd() / "bunkr.toml"
+    return default_path if default_path.is_file() else None
+
+
+def _load_toml_config(path: Path) -> dict:
+    """Load a TOML config file, returning {} on any read/parse failure."""
+    try:
+        with path.open("rb") as f:
+            return tomllib.load(f)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        print(f"Warning: could not read config file '{path}': {exc}")
+        return {}
+
+
+def apply_config_file_defaults(args: Namespace) -> Namespace:
+    """Fill any CLI flag left unset (None) from bunkr.toml, then built-ins.
+
+    Precedence: explicit CLI flag > bunkr.toml value > built-in default.
+    Only mutates attributes that already exist on `args` — parsers that
+    don't include a given option (e.g. --ignore/--include in common_only
+    mode) are left untouched. Unknown TOML keys are ignored. A TOML value
+    with the wrong type is ignored (with a warning) in favor of the
+    built-in default, rather than letting a bad config crash the program.
+    """
+    config_path = _find_config_file(getattr(args, "config", None))
+    toml_data = _load_toml_config(config_path) if config_path else {}
+
+    for key, (builtin_default, is_valid) in _CONFIG_FIELDS.items():
+        if not hasattr(args, key):
+            continue  # this parser variant doesn't expose this option
+
+        if getattr(args, key) is not None:
+            continue  # explicitly set via CLI — config file never overrides it
+
+        if key in toml_data:
+            value = toml_data[key]
+            if is_valid(value):
+                setattr(args, key, value)
+                continue
+            print(
+                f"Warning: bunkr.toml '{key}' has an invalid value "
+                f"({value!r}); using the default instead.",
+            )
+
+        setattr(args, key, builtin_default)
+
+    return args
+
+
+# ============================
 # Argument Parsing
 # ============================
 def add_common_arguments(parser: ArgumentParser) -> None:
@@ -233,23 +342,81 @@ def add_common_arguments(parser: ArgumentParser) -> None:
     parser.add_argument(
         "--no-download-folder",
         action="store_true",
+        default=None,
         help="Save files without a 'Downloads' subfolder.",
     )
     parser.add_argument(
         "--disable-ui",
         action="store_true",
+        default=None,
         help="Disable the user interface.",
     )
     parser.add_argument(
         "--disable-disk-check",
         action="store_true",
+        default=None,
         help="Disable the disk space check for available free space.",
     )
     parser.add_argument(
         "--max-retries",
         type=int,
-        default=MAX_RETRIES,
-        help="Maximum number of retries for downloading a single media.",
+        default=None,
+        help=f"Maximum number of retries for downloading a single media "
+        f"(default: {MAX_RETRIES}).",
+    )
+    parser.add_argument(
+        "--connections",
+        type=int,
+        default=None,
+        help=(
+            "Number of parallel connections used for chunked downloads "
+            f"(default: {DEFAULT_CONNECTIONS}). Set to 1 to disable chunked "
+            "downloading."
+        ),
+    )
+    parser.add_argument(
+        "--rate-limit",
+        type=float,
+        default=None,
+        metavar="KB/S",
+        help=(
+            "Maximum total download speed in KB/s, shared across all "
+            "connections and concurrently downloading files "
+            "(default: unlimited)."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        default=None,
+        help=(
+            "List the files that would be downloaded (with sizes and "
+            "skip/filter status) without downloading or writing anything."
+        ),
+    )
+    parser.add_argument(
+        "--max-concurrent-urls",
+        type=int,
+        default=None,
+        metavar="N",
+        help=(
+            "Number of URLs from URLs.txt to process concurrently "
+            "(default: 1 — sequential, same as before). Values above 1 "
+            "disable the live progress UI (falls back to plain log lines) "
+            "since the progress display only supports tracking one album "
+            "at a time."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        metavar="PATH",
+        help=(
+            "Path to a TOML config file providing default values for any "
+            "of the above flags (default: looks for ./bunkr.toml). "
+            "Explicit CLI flags always take precedence over the config file."
+        ),
     )
     parser.add_argument(
         "--version",
@@ -273,12 +440,14 @@ def setup_parser(
             "--ignore",
             type=str,
             nargs="+",
+            default=None,
             help="Skip files whose names contain any of these substrings.",
         )
         parser.add_argument(
             "--include",
             type=str,
             nargs="+",
+            default=None,
             help="Only download files whose names contain these substrings.",
         )
 
@@ -287,9 +456,15 @@ def setup_parser(
 
 
 def parse_arguments(*, common_only: bool = False) -> Namespace:
-    """Full argument parser (including URL, filters, and common)."""
+    """Full argument parser (including URL, filters, and common).
+
+    After parsing, any flag left unset on the command line is filled in
+    from bunkr.toml (if present) and finally from built-in defaults — see
+    apply_config_file_defaults.
+    """
     parser = (
         setup_parser() if common_only
         else setup_parser(include_url=True, include_filters=True)
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+    return apply_config_file_defaults(args)

--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -6,11 +6,14 @@ integrating with live task displays.
 
 import asyncio
 from asyncio import Semaphore
+from pathlib import Path
 
-from src.config import MAX_RETRIES, MAX_WORKERS, AlbumInfo, DownloadInfo, FailedReason, SessionInfo
+from src.config import MAX_RETRIES, MAX_WORKERS, AlbumInfo, DownloadInfo, FailedReason, SessionInfo, SkippedReason
 from src.crawlers.crawler_utils import get_download_info
+from src.file_utils import truncate_filename
 from src.general_utils import fetch_page
 from src.managers.live_manager import LiveManager
+from src.managers.state_manager import save_album_state
 
 from .media_downloader import MediaDownloader
 
@@ -23,12 +26,22 @@ class AlbumDownloader:
         session_info: SessionInfo,
         album_info: AlbumInfo,
         live_manager: LiveManager,
+        cached_items: dict[str, dict] | None = None,
     ) -> None:
-        """Initialize the AlbumDownloader instance."""
+        """Initialize the AlbumDownloader instance.
+
+        Args:
+            cached_items: Per-item state persisted from a previous run for
+                this same album (keyed by item page URL), used to skip
+                already-completed items without any network round-trip.
+        """
         self.session_info = session_info
         self.album_info = album_info
         self.live_manager = live_manager
         self.failed_downloads = []
+        self.unresolved_failures = 0
+        self.cached_items = dict(cached_items or {})
+        self._state_lock = asyncio.Lock()
 
     async def execute_item_download(
         self,
@@ -39,6 +52,29 @@ class AlbumDownloader:
     ) -> None:
         """Handle the download of an individual item in the album."""
         async with semaphore:
+            # Fast path: this item was confirmed downloaded on a previous
+            # run and the file is still on disk — skip entirely without
+            # fetching the item page or calling the signing API.
+            cached = self.cached_items.get(item_page)
+            if cached and cached.get("status") == "completed":
+                cached_filename = cached.get("filename", "")
+                expected_path = (
+                    Path(self.session_info.download_path)
+                    / truncate_filename(cached_filename)
+                )
+                if expected_path.exists():
+                    task = self.live_manager.add_task(current_task=current_task)
+                    self.live_manager.update_log(
+                        event="Skipped download",
+                        details=f"{cached_filename} has already been downloaded "
+                        "(cached from a previous run).",
+                    )
+                    self.live_manager.update_task(task, completed=100, visible=False)
+                    self.live_manager.update_summary(SkippedReason.ALREADY_DOWNLOADED)
+                    return
+                # The cached file is missing (user deleted it, or the state
+                # was stale) — fall through and process normally below.
+
             task = self.live_manager.add_task(current_task=current_task)
 
             # Process the download of an item
@@ -60,28 +96,47 @@ class AlbumDownloader:
                     ),
                     live_manager=self.live_manager,
                     retries=max_retries,
+                    has_external_retry=True,
                 )
 
                 failed_download = await asyncio.to_thread(media_downloader.download)
                 if failed_download:
-                    self.failed_downloads.append(failed_download)
+                    self.failed_downloads.append({
+                        "id": task,
+                        "filename": item_filename,
+                        "download_link": item_download_link,
+                        "item_url": item_page,
+                    })
+
+                await self._persist_item_state(
+                    item_page, item_filename, failed=failed_download,
+                )
 
             else:
                 # URL could not be resolved after all retries — report as failed
-                # so the user knows which files need attention.
+                # so the user knows which files need attention. There is no
+                # download_link to retry with, so this counts as permanent.
                 self.live_manager.update_log(
                     event="Download failed",
                     details=f"Could not resolve a download URL for {item_filename}.",
                 )
                 self.live_manager.update_task(task, completed=100, visible=False)
                 self.live_manager.update_summary(FailedReason.MAX_RETRIES_REACHED)
+                self.unresolved_failures += 1
+                await self._persist_item_state(item_page, item_filename, failed=True)
 
     async def download_album(
         self,
         max_workers: int = MAX_WORKERS,
         max_retries: int = MAX_RETRIES,
-    ) -> None:
-        """Handle the album download."""
+    ) -> bool:
+        """Handle the album download.
+
+        Returns:
+            True if the album ended with at least one permanently failed
+            item (after the extra retry pass), False if every item either
+            succeeded or was intentionally skipped.
+        """
         num_tasks = len(self.album_info.item_pages)
         self.live_manager.add_overall_task(
             description=self.album_info.album_id,
@@ -97,10 +152,42 @@ class AlbumDownloader:
         await asyncio.gather(*tasks)
 
         # If there are failed downloads, process them after all downloads are complete
-        if self.failed_downloads:
-            await self._process_failed_downloads()
+        still_failed = (
+            await self._process_failed_downloads() if self.failed_downloads else []
+        )
+        return bool(still_failed) or self.unresolved_failures > 0
 
     # Private methods
+    async def _persist_item_state(
+        self, item_page: str, filename: str, *, failed: bool,
+    ) -> None:
+        """Record this item's outcome and persist the album state to disk.
+
+        Marks the item "completed" only when the download did not fail AND
+        the file is verifiably present on disk — this stays accurate
+        regardless of *why* the download call returned success (a fresh
+        download, an already-existed skip, or an offline-domain skip all
+        funnel through here).
+        """
+        is_completed = False
+        if not failed:
+            expected_path = (
+                Path(self.session_info.download_path) / truncate_filename(filename)
+            )
+            is_completed = expected_path.exists()
+
+        async with self._state_lock:
+            self.cached_items[item_page] = {
+                "filename": filename,
+                "status": "completed" if is_completed else "failed",
+            }
+            save_album_state(
+                self.session_info.download_path,
+                self.album_info.album_id,
+                self.album_info.item_pages,
+                self.cached_items,
+            )
+
     async def _fetch_page_with_retries(
         self,
         item_page: str,
@@ -129,19 +216,26 @@ class AlbumDownloader:
         error_message = f"Failed to load page: {item_page}"
         raise RuntimeError(error_message)
 
-    async def _retry_failed_download(self, failed_download_info: DownloadInfo) -> None:
-        """Handle failed downloads and retries them."""
+    async def _retry_failed_download(self, failed_download_info: DownloadInfo) -> bool:
+        """Retry a single failed download once. Returns True if it failed again."""
         media_downloader = MediaDownloader(
             session_info=self.session_info,
             download_info=failed_download_info,
             live_manager=self.live_manager,
             retries=1,  # Retry once for failed downloads
+            has_external_retry=False,  # this is the last chance, finalize either way
         )
         # Run the synchronous download function in a separate thread
-        await asyncio.to_thread(media_downloader.download)
+        return await asyncio.to_thread(media_downloader.download)
 
-    async def _process_failed_downloads(self) -> None:
-        """Process any failed downloads after the initial attempt."""
+    async def _process_failed_downloads(self) -> list[dict]:
+        """Retry every failed download once more.
+
+        Returns:
+            The subset of failed_downloads that failed again on this retry
+            pass (i.e. permanently failed).
+        """
+        still_failed = []
         for data in self.failed_downloads:
             failed_download_info = DownloadInfo(
                 item_url=data["item_url"],
@@ -149,6 +243,14 @@ class AlbumDownloader:
                 filename=data["filename"],
                 task=data["id"],
             )
-            await self._retry_failed_download(failed_download_info)
+            failed_again = await self._retry_failed_download(failed_download_info)
+            if failed_again:
+                still_failed.append(data)
+
+            # Update the persisted state with the outcome of this final pass.
+            await self._persist_item_state(
+                data["item_url"], data["filename"], failed=failed_again,
+            )
 
         self.failed_downloads.clear()
+        return still_failed

--- a/src/downloaders/download_utils.py
+++ b/src/downloaders/download_utils.py
@@ -1,14 +1,35 @@
 """Utilities for handling file downloads with progress tracking."""
 
+from __future__ import annotations
+
+import json
 import logging
+import random
 import shutil
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
+from typing import TYPE_CHECKING
 
+import requests
 from requests import Response
-from requests.exceptions import ChunkedEncodingError
+from requests.exceptions import ChunkedEncodingError, RequestException
 
-from src.config import LARGE_FILE_CHUNK_SIZE, THRESHOLDS
-from src.managers.progress_manager import ProgressManager
+from src.config import (
+    CHUNK_BASE_DELAY,
+    CHUNK_MAX_RETRIES,
+    LARGE_FILE_CHUNK_SIZE,
+    MAX_WORK_UNIT_SIZE,
+    MIN_PARALLEL_SIZE,
+    MIN_WORK_UNIT_SIZE,
+    THRESHOLDS,
+    UNITS_PER_CONNECTION,
+)
+
+if TYPE_CHECKING:
+    from src.managers.live_manager import LiveManager
+    from src.rate_limiter import RateLimiter
 
 
 def get_chunk_size(file_size: int) -> int:
@@ -16,8 +37,6 @@ def get_chunk_size(file_size: int) -> int:
     for threshold, chunk_size in THRESHOLDS:
         if file_size < threshold:
             return chunk_size
-
-    # Return a default chunk size for files larger than the largest threshold
     return LARGE_FILE_CHUNK_SIZE
 
 
@@ -25,19 +44,21 @@ def save_file_with_progress(
     response: Response,
     download_path: str,
     task: int,
-    progress_manager: ProgressManager,
+    live_manager: LiveManager,
+    rate_limiter: RateLimiter | None = None,
 ) -> bool:
     """Save the file from the response to the specified path.
 
-    Add a `.temp` extension if the download is partial. Handles network interruptions
-    such as IncompleteRead and ConnectionResetError (wrapped in ChunkedEncodingError)
-    by marking the download as incomplete.
+    Adds a `.temp` extension while downloading. Handles network interruptions
+    such as IncompleteRead and ConnectionResetError (wrapped in
+    ChunkedEncodingError) by marking the download as incomplete.
+
+    Returns True on failure (partial file kept), False on success.
     """
     file_size = int(response.headers.get("Content-Length", -1))
     if file_size == -1:
         logging.warning("Content length not provided in response headers.")
 
-    # Initialize a temporary download path with the .temp extension
     temp_download_path = Path(download_path).with_suffix(".temp")
     chunk_size = get_chunk_size(file_size)
     total_downloaded = 0
@@ -47,18 +68,364 @@ def save_file_with_progress(
             for chunk in response.iter_content(chunk_size=chunk_size):
                 if chunk is not None:
                     file.write(chunk)
+                    if rate_limiter:
+                        rate_limiter.consume(len(chunk))
                     total_downloaded += len(chunk)
                     completed = (total_downloaded / file_size) * 100
-                    progress_manager.update_task(task, completed=completed)
+                    live_manager.update_task(task, completed=completed)
 
-    # Handle partial downloads caused by network interruptions
     except ChunkedEncodingError:
         return True
 
-    # Rename temp file to final filename if fully downloaded
     if total_downloaded == file_size:
         shutil.move(temp_download_path, download_path)
         return False
 
-    # Keep partial file and return True if incomplete
     return True
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Parallel chunked download
+# ─────────────────────────────────────────────────────────────────────────────
+
+def detect_range_support(
+    url: str, headers: dict[str, str],
+) -> tuple[bool, int]:
+    """Send a HEAD request to detect Range support and retrieve the file size.
+
+    Returns:
+        supports_range: True if the server accepts byte-range requests.
+        content_length: Total file size in bytes, or -1 if unknown.
+    """
+    try:
+        response = requests.head(url, headers=headers, timeout=10)
+        response.raise_for_status()
+        supports_range = (
+            response.headers.get("Accept-Ranges", "").lower() == "bytes"
+        )
+        content_length = int(response.headers.get("Content-Length", -1))
+        return supports_range, content_length
+    except (RequestException, ValueError):
+        return False, -1
+
+
+def should_use_parallel_download(
+    supports_range: bool,
+    content_length: int,
+    num_connections: int,
+) -> bool:
+    """Return True when conditions are met for a parallel chunked download.
+
+    Parallel download requires:
+    - Server supports byte-range requests.
+    - File size is known and exceeds MIN_PARALLEL_SIZE.
+    - More than one connection is requested.
+    """
+    return (
+        supports_range
+        and content_length >= MIN_PARALLEL_SIZE
+        and num_connections > 1
+    )
+
+
+def _compute_unit_ranges(
+    content_length: int,
+    num_connections: int,
+) -> list[tuple[int, int]]:
+    """Split the file into many small work units for work-stealing download.
+
+    The file is divided into roughly UNITS_PER_CONNECTION times more units
+    than worker threads, each sized between MIN_WORK_UNIT_SIZE and
+    MAX_WORK_UNIT_SIZE. Worker threads pull units from a shared queue as
+    they finish, so a slow connection only delays its own next unit instead
+    of blocking threads that finished early.
+
+    The last unit absorbs any remainder so the entire file is always
+    covered.
+    """
+    target_units = max(num_connections * UNITS_PER_CONNECTION, 1)
+    raw_unit_size = content_length / target_units
+    unit_size = int(min(max(raw_unit_size, MIN_WORK_UNIT_SIZE), MAX_WORK_UNIT_SIZE))
+    unit_size = max(unit_size, 1)
+
+    num_units = max(-(-content_length // unit_size), 1)  # ceil division
+
+    ranges = []
+    for i in range(num_units):
+        start = i * unit_size
+        end = (start + unit_size - 1) if i < num_units - 1 else content_length - 1
+        ranges.append((start, end))
+    return ranges
+
+
+def _plan_path(base_path: Path) -> Path:
+    """Return the sidecar metadata path storing the chunk partition plan."""
+    return Path(f"{base_path}.bunkrparts")
+
+
+def _load_or_create_plan(
+    base_path: Path,
+    content_length: int,
+    num_connections: int,
+) -> list[tuple[int, int]]:
+    """Load a previously persisted chunk plan, or compute and save a new one.
+
+    Persisting the plan ensures that resuming a download after changing
+    --connections (or across separate runs) reuses the exact same byte
+    ranges. Without this, a stale .partN file could coincidentally match
+    the expected size of a *different* range under a new plan and be
+    silently merged as corrupt data.
+    """
+    plan_path = _plan_path(base_path)
+
+    if plan_path.exists():
+        try:
+            data = json.loads(plan_path.read_text(encoding="utf-8"))
+            if data.get("content_length") == content_length:
+                return [tuple(pair) for pair in data["ranges"]]
+        except (json.JSONDecodeError, KeyError, OSError):
+            pass  # Corrupt or unreadable metadata — recompute below.
+
+    ranges = _compute_unit_ranges(content_length, num_connections)
+    try:
+        plan_path.write_text(
+            json.dumps({"content_length": content_length, "ranges": ranges}),
+            encoding="utf-8",
+        )
+    except OSError:
+        logging.warning("Could not persist chunk plan for %s", base_path)
+
+    return ranges
+
+
+def _chunk_path(base_path: Path, index: int) -> Path:
+    """Return the .partN path for the given chunk index."""
+    return base_path.with_suffix(f".part{index}")
+
+
+def _attempt_chunk_once(
+    url: str,
+    start: int,
+    end: int,
+    path: Path,
+    headers: dict[str, str],
+    on_progress,
+    rate_limiter: RateLimiter | None = None,
+) -> bool:
+    """Make a single attempt to download one byte-range chunk to disk.
+
+    Any bytes written during a failed attempt are credited back (negative
+    delta) via on_progress so the overall progress bar stays accurate when
+    a retry re-downloads the same range from scratch.
+
+    Returns:
+        True on failure, False on success.
+    """
+    expected = end - start + 1
+    chunk_headers = {**headers, "Range": f"bytes={start}-{end}"}
+    written = 0
+
+    try:
+        with requests.get(
+            url, headers=chunk_headers, stream=True, timeout=30,
+        ) as response:
+            response.raise_for_status()
+            with path.open("wb") as fh:
+                for data in response.iter_content(chunk_size=LARGE_FILE_CHUNK_SIZE):
+                    if data:
+                        fh.write(data)
+                        if rate_limiter:
+                            rate_limiter.consume(len(data))
+                        written += len(data)
+                        on_progress(len(data))
+
+        if path.exists() and path.stat().st_size == expected:
+            return False
+
+        on_progress(-written)
+        return True
+
+    except (RequestException, OSError):
+        on_progress(-written)
+        return True
+
+
+def _download_single_chunk(
+    url: str,
+    start: int,
+    end: int,
+    path: Path,
+    headers: dict[str, str],
+    on_progress,
+    rate_limiter: RateLimiter | None = None,
+) -> bool:
+    """Download one byte-range chunk to disk, retrying with backoff on failure.
+
+    Skips the download entirely when the .partN file already has the correct
+    size, enabling seamless resume across sessions. Each retry re-downloads
+    the chunk from scratch (the previous, incomplete attempt is overwritten).
+
+    Args:
+        url: The signed download URL.
+        start: First byte of the range (inclusive).
+        end: Last byte of the range (inclusive).
+        path: Destination .partN file path.
+        headers: HTTP headers to include in the request.
+        on_progress: Callable(bytes_downloaded) for progress reporting.
+            Called with a negative value to roll back credit after a
+            failed attempt.
+        rate_limiter: Optional shared limiter capping aggregate throughput.
+
+    Returns:
+        True on failure (all retries exhausted), False on success.
+    """
+    expected = end - start + 1
+
+    # Resume: chunk already complete from a previous run, skip entirely.
+    if path.exists() and path.stat().st_size == expected:
+        on_progress(expected)
+        return False
+
+    for attempt in range(1, CHUNK_MAX_RETRIES + 1):
+        failed = _attempt_chunk_once(
+            url, start, end, path, headers, on_progress, rate_limiter,
+        )
+        if not failed:
+            return False
+
+        if attempt < CHUNK_MAX_RETRIES:
+            delay = CHUNK_BASE_DELAY * (2 ** (attempt - 1)) + random.uniform(0, 1)  # noqa: S311
+            time.sleep(delay)
+
+    return True
+
+
+def download_chunks(
+    url: str,
+    content_length: int,
+    num_connections: int,
+    base_path: Path,
+    headers: dict[str, str],
+    task: int,
+    live_manager: LiveManager,
+    rate_limiter: RateLimiter | None = None,
+) -> tuple[list[Path], list[int], bool]:
+    """Download all work units in parallel using a thread pool.
+
+    The file is split into more units than worker threads (see
+    _compute_unit_ranges); ThreadPoolExecutor naturally hands each idle
+    thread the next pending unit as soon as it finishes one, so fast
+    connections pick up extra work instead of waiting on a slow one.
+
+    Progress is tracked in a thread-safe manner across all workers.
+
+    Returns:
+        chunk_paths: Ordered list of .partN file paths (one per unit).
+        expected_sizes: Expected byte count for each unit.
+        any_failed: True if at least one unit did not complete.
+    """
+    ranges = _load_or_create_plan(base_path, content_length, num_connections)
+    chunk_paths = [_chunk_path(base_path, i) for i in range(len(ranges))]
+    expected_sizes = [end - start + 1 for start, end in ranges]
+
+    lock = threading.Lock()
+    total_downloaded = [0]  # mutable container for thread-safe accumulation
+
+    def on_progress(n_bytes: int) -> None:
+        with lock:
+            total_downloaded[0] += n_bytes
+            pct = min((total_downloaded[0] / content_length) * 100, 100.0)
+            live_manager.update_task(task, completed=pct)
+
+    any_failed = False
+    max_workers = min(num_connections, len(ranges))
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {
+            pool.submit(
+                _download_single_chunk,
+                url, start, end, path, headers, on_progress, rate_limiter,
+            ): i
+            for i, ((start, end), path) in enumerate(zip(ranges, chunk_paths))
+        }
+        for future in as_completed(futures):
+            if future.result():
+                any_failed = True
+
+    return chunk_paths, expected_sizes, any_failed
+
+
+def verify_chunks(
+    chunk_paths: list[Path],
+    expected_sizes: list[int],
+) -> bool:
+    """Verify every chunk file exists and has the expected byte count."""
+    return all(
+        path.exists() and path.stat().st_size == size
+        for path, size in zip(chunk_paths, expected_sizes)
+    )
+
+
+def merge_chunks(chunk_paths: list[Path], final_path: Path) -> None:
+    """Concatenate ordered .partN files into the final destination file."""
+    with final_path.open("wb") as dst:
+        for chunk in chunk_paths:
+            with chunk.open("rb") as src:
+                shutil.copyfileobj(src, dst)
+
+
+def cleanup(chunk_paths: list[Path], base_path: Path) -> None:
+    """Remove all .partN chunk files and the plan metadata after a merge."""
+    for path in [*chunk_paths, _plan_path(base_path)]:
+        try:
+            path.unlink(missing_ok=True)
+        except OSError:
+            logging.warning("Could not remove chunk file: %s", path)
+
+
+def save_file_with_chunks(
+    url: str,
+    download_path: str,
+    num_connections: int,
+    task: int,
+    live_manager: LiveManager,
+    headers: dict[str, str],
+    content_length: int,
+    rate_limiter: RateLimiter | None = None,
+) -> bool:
+    """Download a file using parallel byte-range chunks with resume support.
+
+    Each chunk is saved to a dedicated .partN file so that an interrupted
+    download can resume from where it left off on the next run.  Once all
+    chunks are verified, they are merged into the final file and the
+    temporary .partN files are removed.
+
+    Args:
+        url: The signed download URL.
+        download_path: Final destination path for the assembled file.
+        num_connections: Number of parallel download threads/chunks.
+        task: Progress-bar task identifier.
+        live_manager: Live manager used to update the progress bar.
+        headers: HTTP headers to include in every chunk request.
+        content_length: Total file size in bytes (from detect_range_support).
+        rate_limiter: Optional shared limiter capping aggregate throughput
+            across every chunk thread (and every other concurrently
+            downloading file, if the same instance is shared).
+
+    Returns:
+        True on failure (.partN files kept for next resume), False on success.
+    """
+    base_path = Path(download_path)
+
+    chunk_paths, expected_sizes, any_failed = download_chunks(
+        url, content_length, num_connections,
+        base_path, headers, task, live_manager, rate_limiter,
+    )
+
+    if any_failed or not verify_chunks(chunk_paths, expected_sizes):
+        # Keep .partN files so the next run can resume incomplete chunks.
+        return True
+
+    merge_chunks(chunk_paths, base_path)
+    cleanup(chunk_paths, base_path)
+    return False

--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -25,9 +25,19 @@ from src.config import (
     SessionInfo,
     SkippedReason,
 )
-from src.file_utils import truncate_filename, write_on_session_log
+from src.file_utils import (
+    matches_ignore_list,
+    matches_include_list,
+    truncate_filename,
+    write_on_session_log,
+)
 
-from .download_utils import save_file_with_progress
+from .download_utils import (
+    detect_range_support,
+    save_file_with_chunks,
+    save_file_with_progress,
+    should_use_parallel_download,
+)
 
 if TYPE_CHECKING:
     from src.managers.live_manager import LiveManager
@@ -42,17 +52,77 @@ class MediaDownloader:
         download_info: DownloadInfo,
         live_manager: LiveManager,
         retries: int = MAX_RETRIES,
+        *,
+        has_external_retry: bool = False,
     ) -> None:
-        """Initialize the MediaDownloader instance."""
+        """Initialize the MediaDownloader instance.
+
+        Args:
+            has_external_retry: True when a caller (e.g. AlbumDownloader) will
+                retry this item again later if it fails here. When False
+                (the default, used for standalone single-file URLs), a
+                failure is treated as final immediately since nothing else
+                will retry it.
+        """
         self.session_info = session_info
         self.download_info = download_info
         self.live_manager = live_manager
         self.retries = retries
+        self.has_external_retry = has_external_retry
 
     def attempt_download(self, final_path: str) -> bool:
-        """Attempt to download the file with retries."""
+        """Attempt to download the file, using parallel chunks when possible.
+
+        If the server supports byte-range requests and the file is large enough,
+        the download is split into *num_connections* parallel chunks (each saved
+        as a .partN file to allow resuming).  Falls back to the original
+        single-connection stream when chunking is not applicable.
+
+        The chunked path honors the same outer retry budget (--max-retries)
+        as the single-connection fallback: a persistent failure (all internal
+        per-chunk retries exhausted) triggers the same exponential back-off
+        and re-attempt cycle via _retry_with_backoff, instead of giving up
+        after a single call.
+
+        Returns True if the download failed, False on success.
+        """
+        num_connections = getattr(self.session_info.args, "connections", 1)
+        rate_limiter = self.session_info.rate_limiter
+
         for attempt in range(self.retries):
             try:
+                supports_range, content_length = detect_range_support(
+                    self.download_info.download_link, DOWNLOAD_HEADERS,
+                )
+
+                if should_use_parallel_download(
+                    supports_range, content_length, num_connections,
+                ):
+                    # .partN files are preserved on failure so a re-attempt
+                    # (here or on a future run) resumes instead of restarting.
+                    chunked_failed = save_file_with_chunks(
+                        self.download_info.download_link,
+                        final_path,
+                        num_connections,
+                        self.download_info.task,
+                        self.live_manager,
+                        DOWNLOAD_HEADERS,
+                        content_length,
+                        rate_limiter=rate_limiter,
+                    )
+                    if not chunked_failed:
+                        return False
+
+                    # Persistent failure after CHUNK_MAX_RETRIES internal
+                    # attempts — consume one outer retry slot, same as a
+                    # request-level failure on the fallback path below.
+                    if not self._retry_with_backoff(
+                        attempt, event="Retrying chunked download",
+                    ):
+                        break
+                    continue
+
+                # ── Fallback: single-connection streaming download ──────────
                 response = requests.get(
                     self.download_info.download_link,
                     stream=True,
@@ -62,26 +132,29 @@ class MediaDownloader:
                 response.raise_for_status()
 
             except RequestException as req_err:
-                # Exit the loop if not retrying
                 if not self._handle_request_exception(req_err, attempt):
                     break
 
             else:
-                # Returns True if the download failed (marked as partial), otherwise
-                # False to indicate a successful download and exit the loop.
                 return save_file_with_progress(
                     response,
                     final_path,
                     self.download_info.task,
                     self.live_manager,
+                    rate_limiter=rate_limiter,
                 )
 
-        # Download failed
         return True
 
-    def download(self) -> dict | None:
-        """Handle the download process."""
-        is_final_attempt = self.retries == 1
+    def download(self) -> bool:
+        """Handle the download process.
+
+        Returns:
+            True if the item ultimately failed (and no one else will retry
+            it), False if it succeeded, was skipped, or will be retried
+            later by an external caller (has_external_retry=True).
+        """
+        is_final_attempt = not self.has_external_retry
         is_offline = subdomain_is_offline(
             self.download_info.download_link,
             self.session_info.bunkr_status,
@@ -94,14 +167,14 @@ class MediaDownloader:
                 "Check the log file.",
             )
             self._finalize_download(SkippedReason.DOMAIN_OFFLINE)
-            return None
+            return False
 
         formatted_filename = truncate_filename(self.download_info.filename)
         final_path = Path(self.session_info.download_path) / formatted_filename
 
         # Skip download if the file exists or is blacklisted
         if self._skip_file_download(final_path):
-            return None
+            return False
 
         # Attempt to download the file with retries
         try:
@@ -119,7 +192,7 @@ class MediaDownloader:
             return self._handle_failed_download(is_final_attempt=is_final_attempt)
 
         self.live_manager.update_summary(CompletedReason.DOWNLOAD_SUCCESS)
-        return None
+        return False
 
     # Private methods
     def _skip_file_download(self, final_path: str) -> bool:
@@ -154,18 +227,14 @@ class MediaDownloader:
             )
 
         # Check if the file is in the ignore list
-        if ignore_list and any(
-            word in self.download_info.filename for word in ignore_list
-        ):
+        if matches_ignore_list(self.download_info.filename, ignore_list):
             self.live_manager.update_summary(SkippedReason.IGNORE_LIST)
             return log_and_skip_event(
                 f"{self.download_info.filename} matches the ignore list.",
             )
 
         # Check if the file is not in the include list
-        if include_list and all(
-            word not in self.download_info.filename for word in include_list
-        ):
+        if matches_include_list(self.download_info.filename, include_list):
             self.live_manager.update_summary(SkippedReason.INCLUDE_LIST)
             return log_and_skip_event(
                 f"No included words found for {self.download_info.filename}.",
@@ -239,20 +308,22 @@ class MediaDownloader:
         self.live_manager.update_log(event="Request error", details=str(req_err))
         return False
 
-    def _handle_failed_download(self, *, is_final_attempt: bool) -> dict | None:
-        """Handle a failed download after all retry attempts."""
+    def _handle_failed_download(self, *, is_final_attempt: bool) -> bool:
+        """Handle a failed download after all retry attempts.
+
+        Always returns True (failed). When this is not the final attempt,
+        only a log line is emitted — the caller (AlbumDownloader) already
+        has everything it needs to retry the item itself and is expected
+        to do so. The session log is only written on the final attempt,
+        since that is the only point at which the outcome is permanent.
+        """
         if not is_final_attempt:
             self.live_manager.update_log(
                 event="Exceeded retry attempts",
                 details=f"Max retries reached for {self.download_info.filename}. "
                 "It will be retried one more time after all other tasks.",
             )
-            return {
-                "id": self.download_info.task,
-                "filename": self.download_info.filename,
-                "download_link": self.download_info.download_link,
-                "item_url": self.download_info.item_url,
-            }
+            return True
 
         self.live_manager.update_log(
             event="Download failed",
@@ -260,7 +331,7 @@ class MediaDownloader:
             "Check the log file.",
         )
         self._finalize_download(FailedReason.MAX_RETRIES_REACHED)
-        return None
+        return True
 
     def _finalize_download(
         self,

--- a/src/dry_run.py
+++ b/src/dry_run.py
@@ -1,0 +1,165 @@
+"""Preview mode for --dry-run: resolve filenames and sizes without downloading.
+
+Performs the same crawl/resolve/filter steps as a real download (page
+fetch, signed-URL resolution, --ignore/--include filtering, on-disk and
+cached-state existence checks) but never calls MediaDownloader and never
+writes any downloaded content to disk.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from rich.console import Console
+from rich.table import Table
+
+from src.config import DOWNLOAD_HEADERS, MAX_WORKERS
+from src.crawlers.crawler_utils import get_download_info
+from src.downloaders.download_utils import detect_range_support
+from src.file_utils import matches_ignore_list, matches_include_list, truncate_filename
+from src.general_utils import fetch_page
+
+if TYPE_CHECKING:
+    from src.config import SessionInfo
+
+_STATUS_LABELS: dict[str, tuple[str, str]] = {
+    "would_download": ("Would download", "green"),
+    "already_downloaded": ("Already downloaded", "dim"),
+    "filtered_ignore": ("Filtered (ignore list)", "yellow"),
+    "filtered_include": ("Filtered (include list)", "yellow"),
+    "unresolved": ("Could not resolve URL", "red"),
+    "fetch_failed": ("Failed to fetch page", "red"),
+}
+
+
+def _format_size(num_bytes: int | None) -> str:
+    """Format a byte count as a human-readable size string."""
+    if num_bytes is None:
+        return "unknown"
+    value = float(num_bytes)
+    for unit in ("B", "KB", "MB", "GB"):
+        if value < 1024:
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{value:.1f} TB"
+
+
+async def _resolve_item(
+    item_page: str,
+    session_info: SessionInfo,
+    cached_items: dict[str, dict],
+    semaphore: asyncio.Semaphore,
+) -> dict:
+    """Resolve filename, size and status for one item without downloading it."""
+    async with semaphore:
+        cached = cached_items.get(item_page)
+        if cached and cached.get("status") == "completed":
+            filename = cached.get("filename", "")
+            expected_path = (
+                Path(session_info.download_path) / truncate_filename(filename)
+            )
+            if expected_path.exists():
+                return {
+                    "filename": filename,
+                    "size": expected_path.stat().st_size,
+                    "status": "already_downloaded",
+                }
+            # Cached "completed" entry is stale (file missing) — fall
+            # through and resolve it fresh, same as a real download would.
+
+        item_soup = await fetch_page(item_page)
+        if item_soup is None:
+            return {"filename": item_page, "size": None, "status": "fetch_failed"}
+
+        download_link, filename = await get_download_info(item_page, item_soup)
+        if not download_link:
+            return {"filename": filename, "size": None, "status": "unresolved"}
+
+        args = session_info.args
+        ignore_list = getattr(args, "ignore", None) if args else None
+        include_list = getattr(args, "include", None) if args else None
+
+        if matches_ignore_list(filename, ignore_list):
+            return {"filename": filename, "size": None, "status": "filtered_ignore"}
+        if matches_include_list(filename, include_list):
+            return {"filename": filename, "size": None, "status": "filtered_include"}
+
+        final_path = Path(session_info.download_path) / truncate_filename(filename)
+        if final_path.exists():
+            return {
+                "filename": filename,
+                "size": final_path.stat().st_size,
+                "status": "already_downloaded",
+            }
+
+        _, content_length = await asyncio.to_thread(
+            detect_range_support, download_link, DOWNLOAD_HEADERS,
+        )
+        size = content_length if content_length and content_length > 0 else None
+        return {"filename": filename, "size": size, "status": "would_download"}
+
+
+async def run_dry_run(
+    album_id: str,
+    item_pages: list[str],
+    session_info: SessionInfo,
+    cached_items: dict[str, dict],
+    console: Console,
+    max_workers: int = MAX_WORKERS,
+) -> None:
+    """Print a preview table of what a download would do, without downloading.
+
+    Args:
+        album_id: Album identifier (or single-item identifier) used as the
+            table title.
+        item_pages: The item page URLs that would be processed.
+        session_info: Session context (download path, args, etc.).
+        cached_items: Per-item state persisted from a previous run, used to
+            report "already downloaded" without a network round-trip.
+        console: Rich console to print the report to.
+        max_workers: Concurrency limit for resolving items, matching the
+            same default used by real album downloads.
+    """
+    semaphore = asyncio.Semaphore(max_workers)
+    results = await asyncio.gather(
+        *(_resolve_item(p, session_info, cached_items, semaphore) for p in item_pages),
+    )
+
+    table = Table(title=f"Dry run — {album_id} ({len(item_pages)} item(s))")
+    table.add_column("Filename", overflow="fold")
+    table.add_column("Size", justify="right")
+    table.add_column("Status")
+
+    total_download_bytes = 0
+    counts: dict[str, int] = {}
+
+    for item in results:
+        status = item["status"]
+        counts[status] = counts.get(status, 0) + 1
+        if status == "would_download" and item["size"]:
+            total_download_bytes += item["size"]
+
+        label, color = _STATUS_LABELS.get(status, (status, "white"))
+        table.add_row(
+            item["filename"] or "(unknown)",
+            _format_size(item["size"]),
+            f"[{color}]{label}[/{color}]",
+        )
+
+    console.print(table)
+    console.print(
+        f"\nWould download: {counts.get('would_download', 0)} file(s), "
+        f"{_format_size(total_download_bytes)} total",
+    )
+    if counts.get("already_downloaded"):
+        console.print(f"Already downloaded: {counts['already_downloaded']} file(s)")
+
+    filtered_total = counts.get("filtered_ignore", 0) + counts.get("filtered_include", 0)
+    if filtered_total:
+        console.print(f"Filtered out: {filtered_total} file(s)")
+
+    unresolved_total = counts.get("unresolved", 0) + counts.get("fetch_failed", 0)
+    if unresolved_total:
+        console.print(f"[red]Could not resolve: {unresolved_total} file(s)[/red]")

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -11,7 +11,7 @@ import os
 import re
 import shutil
 import sys
-from datetime import datetime, timezone
+from datetime import datetime, timezoneش
 from pathlib import Path
 
 from .config import (
@@ -170,3 +170,18 @@ def truncate_filename(filename: str) -> str:
 
     formatted_filename = f"{name}{extension}"
     return str(filename_path.with_name(formatted_filename))
+
+
+def matches_ignore_list(filename: str, ignore_list: list[str] | None) -> bool:
+    """Return True if filename matches any word in the --ignore list."""
+    return bool(ignore_list) and any(word in filename for word in ignore_list)
+
+
+def matches_include_list(filename: str, include_list: list[str] | None) -> bool:
+    """Return True if --include is set and filename matches none of its words.
+
+    A True return means the file should be EXCLUDED (it failed to match the
+    required include list), mirroring matches_ignore_list's "should exclude"
+    semantics so both predicates compose the same way at call sites.
+    """
+    return bool(include_list) and all(word not in filename for word in include_list)

--- a/src/managers/state_manager.py
+++ b/src/managers/state_manager.py
@@ -1,0 +1,70 @@
+"""Module for persisting per-album crawl/download state across runs.
+
+For very large albums (many paginated pages, hundreds of items), re-running
+the downloader would otherwise re-crawl every album listing page and
+re-fetch every item page plus call the signing API even for files that were
+already downloaded successfully on a previous run.
+
+This module persists a small JSON sidecar file inside the album's download
+folder so that, on a re-run for the same album:
+- The paginated item-page crawl can be skipped entirely.
+- Items already confirmed downloaded (and still present on disk) are
+  recognized immediately, without any network round-trip.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+
+STATE_FILENAME = ".bunkr_state.json"
+
+
+def _state_path(download_path: str) -> Path:
+    """Return the sidecar state-file path for the given download folder."""
+    return Path(download_path) / STATE_FILENAME
+
+
+def load_album_state(download_path: str) -> dict | None:
+    """Load the persisted album state for this download folder.
+
+    Returns:
+        A dict with "album_id", "item_pages" and "items" keys, or None if
+        no valid state file is present (first run, or corrupt/foreign file).
+    """
+    path = _state_path(download_path)
+    if not path.exists():
+        return None
+
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        logging.warning("Could not read album state file: %s", path)
+        return None
+
+    if not isinstance(data, dict) or "album_id" not in data:
+        return None
+
+    data.setdefault("item_pages", [])
+    data.setdefault("items", {})
+    return data
+
+
+def save_album_state(
+    download_path: str,
+    album_id: str,
+    item_pages: list[str],
+    items: dict[str, dict],
+) -> None:
+    """Persist the full album state, overwriting any previous file."""
+    path = _state_path(download_path)
+    try:
+        path.write_text(
+            json.dumps(
+                {"album_id": album_id, "item_pages": item_pages, "items": items},
+            ),
+            encoding="utf-8",
+        )
+    except OSError:
+        logging.warning("Could not write album state file: %s", path)

--- a/src/rate_limiter.py
+++ b/src/rate_limiter.py
@@ -1,0 +1,60 @@
+"""Thread-safe token-bucket rate limiter for capping aggregate download speed.
+
+A single RateLimiter instance is shared across every download thread (all
+chunks of all files in the current run), so --rate-limit caps the *total*
+bandwidth used by the process — not a per-connection or per-file limit that
+would be trivially multiplied by --connections or concurrent album items.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class RateLimiter:
+    """Caps aggregate throughput across every thread sharing this instance."""
+
+    def __init__(self, rate_bytes_per_sec: float | None) -> None:
+        """Initialize the limiter.
+
+        Args:
+            rate_bytes_per_sec: Maximum aggregate bytes/sec across all
+                callers. None or a non-positive value disables throttling
+                entirely (consume() becomes a no-op).
+        """
+        self.rate = (
+            rate_bytes_per_sec if rate_bytes_per_sec and rate_bytes_per_sec > 0
+            else None
+        )
+        self._tokens = float(self.rate or 0)
+        self._last_refill = time.monotonic()
+        self._lock = threading.Lock()
+
+    def consume(self, n_bytes: int) -> None:
+        """Block the calling thread until n_bytes of bandwidth budget is free.
+
+        Safe to call concurrently from many threads; each call only blocks
+        the thread that called it; other threads keep accumulating/spending
+        tokens independently while one is sleeping.
+
+        A single call may request more bytes than the bucket's max burst
+        capacity (self.rate) — e.g. a single large HTTP read. Tokens are
+        allowed to go negative ("debt") in that case rather than requiring
+        tokens >= n_bytes, which could never be satisfied since tokens are
+        capped at self.rate; the resulting sleep duration below correctly
+        repays that debt at the configured rate either way.
+        """
+        if self.rate is None or n_bytes <= 0:
+            return
+
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_refill
+            self._last_refill = now
+            self._tokens = min(self.rate, self._tokens + elapsed * self.rate)
+            self._tokens -= n_bytes
+            deficit = -self._tokens
+
+        if deficit > 0:
+            time.sleep(deficit / self.rate)


### PR DESCRIPTION
# Summary

This PR adds six new features to the core downloader. Each is
independent but they compose naturally — for example, `--rate-limit`
applies to both the chunked and single-connection paths, and `--dry-run`
uses the same filter predicates as the real downloader.

---

# Feature 1 — Parallel chunked download with work-stealing

For files served with `Accept-Ranges: bytes` and larger than **5 MB**, the
download is split into many small work units instead of one stream.

A `ThreadPoolExecutor` hands idle threads the next pending unit as soon
as they finish one, so a slow or throttled connection only delays its
own next unit rather than blocking the entire download (work-stealing).

### New CLI flag

- `--connections N` (default: `4`)
- Set to `1` to disable chunked downloading and use the original
  single-connection path.

### Resume support

Each unit is saved to a `.partN` sidecar file.

A `.bunkrparts` metadata file persists the exact byte-range partition
plan so that changing `--connections` between two runs cannot cause a
`.partN` file to be silently matched to a wrong range on resume.

### Fallbacks

Falls back to the original single-connection streaming path when:

- the server does not advertise range support,
- the content length is unknown,
- or `--connections 1` is passed.

The outer `--max-retries` loop now applies to the chunked path as well.
Previously a chunked failure returned immediately, making
`--max-retries` have no effect on it.

### Files changed

- `src/downloaders/download_utils.py`
- `src/downloaders/media_downloader.py`
- `src/config.py`

---

# Feature 2 — Per-album state persistence for cross-session cache

A small JSON sidecar (`.bunkr_state.json`) is written inside each album's
download folder after every item outcome.

On a re-run for the same album:

- The paginated item-page crawl is skipped entirely.
- Previously downloaded items are recognised without any network
  requests if the file still exists.

If the file has been deleted, the cache entry is treated as stale and
the item is downloaded again.

All sidecar writes are protected by an `asyncio.Lock`.

### Files changed

- `src/managers/state_manager.py`
- `src/downloaders/album_downloader.py`
- `downloader.py`

---

# Feature 3 — Aggregate bandwidth rate limiting

A token-bucket `RateLimiter` is constructed once per run and shared
across every download thread and concurrently downloading file, making
`--rate-limit` a true aggregate bandwidth cap.

### New CLI flag

- `--rate-limit KB/S`

A previous spin-wait implementation could deadlock when a single read
requested more bytes than the bucket capacity.

The implementation now uses a debt model that correctly handles
arbitrarily large reads.

### Files changed

- `src/rate_limiter.py`
- `src/downloaders/download_utils.py`
- `src/downloaders/media_downloader.py`
- `src/config.py`
- `downloader.py`
- `main.py`

---

# Feature 4 — `--dry-run` preview mode

Performs the full crawl and URL resolution process but never downloads
or writes any files.

Outputs a Rich table showing:

- filename
- resolved size
- per-item status

Status values:

- `would_download`
- `already_downloaded`
- `filtered_ignore`
- `filtered_include`
- `unresolved`
- `fetch_failed`

Filter logic has been extracted into shared predicates so both real
downloads and dry-runs behave identically.

### New CLI flag

- `--dry-run`

### Files changed

- `src/dry_run.py`
- `src/file_utils.py`
- `src/downloaders/media_downloader.py`
- `src/config.py`
- `downloader.py`
- `main.py`

---

# Feature 5 — `--max-concurrent-urls`

Processes URLs from `URLs.txt` concurrently using `asyncio.gather`
bounded by a `Semaphore`.

The live progress UI is automatically disabled when more than one album
is processed simultaneously.

The shared `RateLimiter` remains an aggregate cap across all concurrent
URLs.

### New CLI flag

- `--max-concurrent-urls N`

### Files changed

- `src/config.py`
- `main.py`

---

# Feature 6 — `bunkr.toml` configuration support

Adds persistent configuration through a TOML file.

Configuration precedence:

1. CLI flags
2. `bunkr.toml`
3. Built-in defaults

Supports:

- explicit `--config`
- automatic `./bunkr.toml`
- fallback defaults

Uses:

- `tomllib` on Python ≥3.11
- `tomli` fallback on Python 3.10

Includes validation for malformed TOML, wrong value types,
bool-as-int rejection, and unknown keys.

### New CLI flag

- `--config PATH`

### Files changed

- `src/config.py`
- `requirements.txt`
- `bunkr.toml.example`

---

# Testing

- ✅ Ruff checks pass.
- ✅ Chunked download integrity verified.
- ✅ Resume functionality verified.
- ✅ Aggregate rate limiting verified.
- ✅ Dry-run behaviour verified.
- ✅ Concurrent URL processing verified.
- ✅ Configuration precedence verified.