### PR TITLE
Fix IndexError crash from list-position-based overall task tracking

### DIFF
--- a/src/managers/progress_manager.py
+++ b/src/managers/progress_manager.py
@@ -7,12 +7,14 @@ monitoring task completion.
 from __future__ import annotations
 
 import shutil
+import threading
 
 from rich.panel import Panel
 from rich.progress import (
     BarColumn,
     Progress,
     SpinnerColumn,
+    TaskID,
     TextColumn,
     TimeRemainingColumn,
 )
@@ -43,19 +45,38 @@ class ProgressManager:
         self.task_progress = self._create_progress_bar(show_time=True)
         self.num_tasks = 0
 
+        # Explicit reference to the overall task currently being tracked, set by
+        # add_overall_task(). This replaces guessing "the current task" from list
+        # ordering (e.g. tasks[-1]), which breaks once a task can be removed or
+        # re-buffered out of order.
+        self.current_overall_task_id: TaskID | None = None
+
+        # IDs of overall tasks already queued for cleanup, so a finished task is
+        # only ever enqueued into overall_buffer once, no matter how many more
+        # progress updates arrive for it afterwards.
+        self._buffered_overall_task_ids: set[TaskID] = set()
+
+        # Every public update touches shared Progress state (task lists, the
+        # cleanup buffer, current_overall_task_id) from whichever thread the
+        # download happened to run on -- up to MAX_WORKERS x num_connections
+        # threads can call update_task concurrently. This lock makes each
+        # update atomic.
+        self._lock = threading.Lock()
+
     def get_panel_width(self) -> int:
         """Return the width of the panel."""
         return self.config.panel_width
 
     def add_overall_task(self, description: str, num_tasks: int) -> None:
         """Add an overall progress task with a given description and total tasks."""
-        self.num_tasks = num_tasks
-        overall_description = self._adjust_description(description)
-        self.overall_progress.add_task(
-            f"[{self.config.color}]{overall_description}",
-            total=num_tasks,
-            completed=0,
-        )
+        with self._lock:
+            self.num_tasks = num_tasks
+            overall_description = self._adjust_description(description)
+            self.current_overall_task_id = self.overall_progress.add_task(
+                f"[{self.config.color}]{overall_description}",
+                total=num_tasks,
+                completed=0,
+            )
 
     def add_task(self, current_task: int = 0, total: int = 100) -> int:
         """Add an individual task to the task progress bar."""
@@ -74,13 +95,14 @@ class ProgressManager:
         visible: bool = True,
     ) -> None:
         """Update the progress of an individual task and the overall progress."""
-        self.task_progress.update(
-            task_id,
-            completed=completed if completed is not None else None,
-            advance=advance if completed is None else None,
-            visible=visible,
-        )
-        self._update_overall_task(task_id)
+        with self._lock:
+            self.task_progress.update(
+                task_id,
+                completed=completed if completed is not None else None,
+                advance=advance if completed is None else None,
+                visible=visible,
+            )
+            self._update_overall_task(task_id)
 
     def create_progress_table(self, min_panel_width: int = 30) -> Table:
         """Create a formatted progress table for tracking the download."""
@@ -108,27 +130,63 @@ class ProgressManager:
 
     # Private methods
     def _update_overall_task(self, task_id: int) -> None:
-        """Advance the overall progress bar and removes old tasks."""
-        # Access the latest task dynamically
-        current_overall_task = self.overall_progress.tasks[-1]
+        """Advance the overall progress bar and removes old tasks.
 
-        # If the task is finished, remove it and update the overall progress
+        Safe to call even after the overall task for this album has already
+        been cleaned up (e.g. a late progress callback from a retry, or from
+        a slow parallel-chunk worker that finishes after the rest): in that
+        case current_overall_task_id is None and this is a no-op instead of
+        crashing.
+        """
+        overall_task_id = self.current_overall_task_id
+        if overall_task_id is None:
+            return
+
+        current_overall_task = self._get_overall_task(overall_task_id)
+        if current_overall_task is None:
+            # The task was removed from under us; forget the stale id.
+            self.current_overall_task_id = None
+            return
+
+        # If the individual task is finished, advance the overall progress once.
         if self.task_progress.tasks[task_id].finished:
-            self.overall_progress.advance(current_overall_task.id)
+            self.overall_progress.advance(overall_task_id)
             self.task_progress.update(task_id, visible=False)
+            current_overall_task = self._get_overall_task(overall_task_id)
 
-        # Track completed overall tasks
-        if current_overall_task.finished:
+        # Queue completed overall tasks for cleanup exactly once, no matter how
+        # many further updates arrive for an already-finished overall task.
+        if (
+            current_overall_task is not None
+            and current_overall_task.finished
+            and overall_task_id not in self._buffered_overall_task_ids
+        ):
+            self._buffered_overall_task_ids.add(overall_task_id)
             self.config.overall_buffer.append(current_overall_task)
 
         # Cleanup completed overall tasks
         self._cleanup_completed_overall_tasks()
+
+    def _get_overall_task(self, task_id: TaskID):  # noqa: ANN202
+        """Look up an overall task by id, returning None if it no longer exists."""
+        return next(
+            (task for task in self.overall_progress.tasks if task.id == task_id),
+            None,
+        )
 
     def _cleanup_completed_overall_tasks(self) -> None:
         """Remove the oldest completed overall task from the buffer and progress bar."""
         if len(self.config.overall_buffer) == self.config.overall_buffer.maxlen:
             completed_overall_id = self.config.overall_buffer.popleft().id
             self.overall_progress.remove_task(completed_overall_id)
+            self._buffered_overall_task_ids.discard(completed_overall_id)
+
+            # If the task we just removed was the one still being tracked as
+            # "current" (e.g. lingering retries for a finished album kept it
+            # alive in the buffer), clear the reference so any further stray
+            # update becomes a safe no-op instead of touching a removed task.
+            if completed_overall_id == self.current_overall_task_id:
+                self.current_overall_task_id = None
 
     # Static methods
     @staticmethod


### PR DESCRIPTION
## Fix progress tracking crash caused by duplicate task cleanup

`_update_overall_task` was relying on `self.overall_progress.tasks[-1]` to infer the current task. It also unconditionally re-added already-finished tasks to the cleanup buffer (`overall_buffer`, `maxlen=5`) on every subsequent progress update.

For albums where items arrive late for retry (for example, an offline item retried after the main download pass, or a delayed parallel chunk worker callback), this caused the buffer to fill with duplicate task references. Eventually, the only active overall progress task could be removed from Rich's internal task list.

Any further progress update would then attempt to access an empty task list, resulting in:

```text
IndexError: list index out of range
```

## Changes

* Track the current overall task using an explicit ID (`current_overall_task_id`) instead of inferring it from the task list position.
* Add finished tasks to the cleanup buffer only once by tracking already-buffered task IDs.
* Clear the tracked task ID when a task is removed, so any later stray updates safely become no-ops instead of causing a crash.
* Protect the update path with `threading.Lock`, since multiple threads (`MAX_WORKERS × --connections`) can update progress concurrently with the parallel chunk-download feature.

## Verification

Verified with:

* Unit tests reproducing the reported traceback (fails on the old implementation, passes with this fix).
* A concurrency stress test.
* A multi-album cleanup-buffer overflow test.

## Note

This is a synthetic reproduction based on the traceback provided in the report. It has not yet been confirmed against the original reporter's exact album. Further investigation will follow if the issue persists after this fix.
