### PR TITLE
Fix: album's progress, keeps getting longer and longer

### DIFF
--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -317,6 +317,19 @@ class MediaDownloader:
                 details=f"Max retries reached for {self.download_info.filename}. "
                 "It will be retried one more time after all other tasks.",
             )
+            # Hide this row now. AlbumDownloader only retries failed items in
+            # _process_failed_downloads, which runs *after every item in the
+            # album has been attempted* -- on a large album with many dead
+            # links, leaving each of these rows visible in the meantime piles
+            # up hundreds of stalled "File N/total" entries and pushes the
+            # actively-downloading items off screen. The row reappears on its
+            # own during the later retry if that retry makes real progress
+            # (update_task defaults to visible=True for progress callbacks).
+            self.live_manager.update_task(
+                self.download_info.task,
+                completed=None,
+                visible=False,
+            )
             return True
 
         self.live_manager.update_log(
@@ -331,7 +344,7 @@ class MediaDownloader:
         self,
         reason: FailedReason | SkippedReason,
         *,
-        completed: int | None = None,
+        completed: int | None = 100,
     ) -> None:
         outcome = reason.__class__.__name__.replace("Reason", "")
 


### PR DESCRIPTION
## Fix failed-download progress handling

This fixes two related issues in the failed-download handling path.

### Problems

#### Album Progress panel grows without bound

`_handle_failed_download()` only hid a task's progress row (`visible=False`) on the **final** retry attempt.

During the main download pass (the initial, non-final attempt), failed items remained visible indefinitely because retries are only processed later by `_process_failed_downloads()`, after every item in the album has already been attempted.

On albums containing many dead or invalid links, this resulted in hundreds of stalled progress rows accumulating, eventually pushing actively downloading items off the screen.

#### Overall progress undercounting

`_finalize_download()` defaulted its `completed` parameter to `None`.

As a result, items finalized as offline-domain skips or permanent failures never had their individual progress task marked as completed (`completed >= total`), preventing the overall progress bar from reaching 100%.

### Fix

* Hide failed task rows immediately in `_handle_failed_download()`, even during non-final attempts.
* Allow the row to reappear automatically if a later retry makes progress.
* Change the default value of `_finalize_download(completed=100)` to match every other terminal `update_task()` call in the codebase.

### Verification

Verified end-to-end using a local mixed success/404 test album (no real Bunkr URLs involved).

Before the fix:

* Failed rows remained visible after the main download pass.
* Overall progress undercounted completed work.

After the fix:

* No stale progress rows remain after the main pass.
* Overall progress correctly reaches 100% once every item has been processed.
