### PR TITLE
Add --clean-name flag to preserve original filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,25 @@ You can either download an entire album or a specific file:
 ```
 python3 downloader.py https://bunkr.si/a/PUK068QE       # Download album
 python3 downloader.py https://bunkr.fi/f/gBrv5f8tAGlGW  # Download single media
+
+## Preserve original filenames
+
+By default the downloader may generate filenames based on the URL. Use the
+`--clean-name` flag to preserve the original filename found on the item page.
+
+### Usage
+
+```bash
+python3 downloader.py <bunkr_url> --clean-name
+```
+
+### Dry-run example
+
+```bash
+python3 downloader.py --dry-run --clean-name <bunkr_url>
+```
+
+The flag is optional and defaults to `False`.
 ```
 
 ## Selective Download

--- a/downloader.py
+++ b/downloader.py
@@ -130,7 +130,11 @@ async def handle_download_process(
         return await album_downloader.download_album(max_retries=max_retries)
 
     # Single item download
-    download_link, filename = await get_download_info(url, initial_soup)
+    download_link, filename = await get_download_info(
+        url,
+        initial_soup,
+        session_info.clean_name,
+    )
     live_manager.add_overall_task(identifier, num_tasks=1)
     task = live_manager.add_task()
 
@@ -199,6 +203,7 @@ async def execute_url_dry_run(
     )
     session_info = SessionInfo(
         args=args, bunkr_status=bunkr_status, download_path=download_path,
+        clean_name=args.clean_name,
     )
     item_pages, cached_items = await get_album_items(
         validated_url, soup, download_path, identifier,
@@ -248,6 +253,7 @@ async def validate_and_download(
         args=args,
         bunkr_status=bunkr_status,
         download_path=download_path,
+        clean_name=args.clean_name,
         rate_limiter=rate_limiter,
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -190,6 +190,7 @@ class SessionInfo:
     args: Namespace | None
     bunkr_status: dict[str, str]
     download_path: str
+    clean_name: bool
     rate_limiter: RateLimiter | None = None
 
 @dataclass(slots=True)
@@ -394,6 +395,12 @@ def add_common_arguments(parser: ArgumentParser) -> None:
         action="store_true",
         default=None,
         help="Disable the disk space check for available free space.",
+    )
+    parser.add_argument(
+        "--clean-name",
+        action="store_true",
+        default=False,
+        help="Keep the original filenames of downloaded files.",
     )
     parser.add_argument(
         "--max-retries",

--- a/src/crawlers/crawler_utils.py
+++ b/src/crawlers/crawler_utils.py
@@ -160,7 +160,7 @@ def format_item_filename(original_filename: str, url_based_filename: str) -> str
     return f"{valid_original_base}-{url_base}{extension}"
 
 
-async def get_download_info(item_url: str, item_soup: BeautifulSoup) -> tuple:
+async def get_download_info(item_url: str, item_soup: BeautifulSoup, clean_name: bool) -> tuple:
     """Gather download information (link and filename) for the item."""
     async with aiohttp.ClientSession() as session:
         item_download_link = await get_item_download_link(
@@ -168,6 +168,9 @@ async def get_download_info(item_url: str, item_soup: BeautifulSoup) -> tuple:
         )
 
     item_filename = get_item_filename(item_soup)
+    if clean_name:
+        return item_download_link, item_filename
+
     url_based_filename = (
         get_url_based_filename(item_download_link) if item_download_link else None
     )

--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -92,6 +92,7 @@ class AlbumDownloader:
             item_download_link, item_filename = await get_download_info(
                 item_page,
                 item_soup,
+                self.session_info.clean_name,
             )
 
             # Download item

--- a/src/dry_run.py
+++ b/src/dry_run.py
@@ -88,7 +88,7 @@ async def _resolve_item(
         if item_soup is None:
             return {"filename": item_page, "size": None, "status": "fetch_failed"}
 
-        download_link, filename = await get_download_info(item_page, item_soup)
+        download_link, filename = await get_download_info(item_page, item_soup, session_info.clean_name)
         if not download_link:
             return {"filename": filename, "size": None, "status": "unresolved"}
 


### PR DESCRIPTION
### Summary

This PR adds support for `--clean-name` flag to preserve original filenames instead of the current obfuscated filenames.

### How to test
Dry-run (only preview, no download):

```bash
python downloader.py --dry-run --clean-name <bunk_url>
```

Compare behavior without `--clean-name`:
```bash
python downloader.py --dry-run <bunk_url>
```

### Issue Reference
#4 