### PR TITLE
Add --clean-name flag & fix short filename formatting bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,28 @@ python3 downloader.py <bunkr_url>
 
 You can either download an entire album or a specific file:
 
-```
+```bash
 python3 downloader.py https://bunkr.si/a/PUK068QE       # Download album
 python3 downloader.py https://bunkr.fi/f/gBrv5f8tAGlGW  # Download single media
 ```
+
+## Preserve original filenames
+
+By default the downloader may generate filenames based on the URL. Use the `--clean-name` flag to preserve the original filename found on the item page. If multiple files in an album share the exact same original filename, an index suffix like `(1)`, `(2)` will be automatically appended to avoid collisions.
+
+### Usage
+
+```bash
+python3 downloader.py <bunkr_url> --clean-name
+```
+
+### Dry-run example
+
+```bash
+python3 downloader.py --dry-run --clean-name <bunkr_url>
+```
+
+The flag is optional and defaults to `False`.
 
 ## Selective Download
 

--- a/bunkr.toml.example
+++ b/bunkr.toml.example
@@ -19,6 +19,9 @@
 # Skip the free-disk-space check before downloading.
 # disable_disk_check = false
 
+# Preserve the original filename and add a (N) suffix to prevent duplicates.
+# clean_name = false
+
 # Maximum number of retries for downloading a single media file.
 # max_retries = 5
 

--- a/downloader.py
+++ b/downloader.py
@@ -129,7 +129,11 @@ async def handle_download_process(
         return await album_downloader.download_album(max_retries=max_retries)
 
     # Single item download
-    download_link, filename = await get_download_info(url, initial_soup)
+    download_link, filename = await get_download_info(
+        url,
+        initial_soup,
+        session_info.clean_name,
+    )
     live_manager.add_overall_task(identifier, num_tasks=1)
     task = live_manager.add_task()
 
@@ -197,7 +201,10 @@ async def execute_url_dry_run(
         no_download_folder=args.no_download_folder,
     )
     session_info = SessionInfo(
-        args=args, bunkr_status=bunkr_status, download_path=download_path,
+        args=args,
+        bunkr_status=bunkr_status,
+        download_path=download_path,
+        clean_name=args.clean_name,
     )
     item_pages, cached_items = await get_album_items(
         validated_url, soup, download_path, identifier,
@@ -247,6 +254,7 @@ async def validate_and_download(
         args=args,
         bunkr_status=bunkr_status,
         download_path=download_path,
+        clean_name=args.clean_name,
         rate_limiter=rate_limiter,
     )
 

--- a/src/config.py
+++ b/src/config.py
@@ -190,6 +190,7 @@ class SessionInfo:
     args: Namespace | None
     bunkr_status: dict[str, str]
     download_path: str
+    clean_name: bool
     rate_limiter: RateLimiter | None = None
 
 @dataclass(slots=True)
@@ -394,6 +395,12 @@ def add_common_arguments(parser: ArgumentParser) -> None:
         action="store_true",
         default=None,
         help="Disable the disk space check for available free space.",
+    )
+    parser.add_argument(
+        "--clean-name",
+        action="store_true",
+        default=False,
+        help="Keep the original filenames of downloaded files.",
     )
     parser.add_argument(
         "--max-retries",

--- a/src/crawlers/crawler_utils.py
+++ b/src/crawlers/crawler_utils.py
@@ -152,7 +152,11 @@ def format_item_filename(original_filename: str, url_based_filename: str) -> str
     extension = Path(original_filename).suffix
     url_base = Path(url_based_filename).stem
 
-    if original_base in url_base:
+    has_matching_prefix = url_base.startswith((
+        f"{original_base}-",
+        f"{original_base}_",
+    ))
+    if url_base == original_base or has_matching_prefix:
         return url_based_filename
 
     # Combine the base names with a hyphen and append the extension

--- a/src/crawlers/crawler_utils.py
+++ b/src/crawlers/crawler_utils.py
@@ -160,7 +160,7 @@ def format_item_filename(original_filename: str, url_based_filename: str) -> str
     return f"{valid_original_base}-{url_base}{extension}"
 
 
-async def get_download_info(item_url: str, item_soup: BeautifulSoup) -> tuple:
+async def get_download_info(item_url: str, item_soup: BeautifulSoup, clean_name: bool) -> tuple:
     """Gather download information (link and filename) for the item."""
     async with aiohttp.ClientSession() as session:
         item_download_link = await get_item_download_link(
@@ -168,6 +168,9 @@ async def get_download_info(item_url: str, item_soup: BeautifulSoup) -> tuple:
         )
 
     item_filename = get_item_filename(item_soup)
+    if clean_name:
+        return item_download_link, item_filename
+
     url_based_filename = (
         get_url_based_filename(item_download_link) if item_download_link else None
     )

--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -21,7 +21,7 @@ from src.config import (
     SkippedReason,
 )
 from src.crawlers.crawler_utils import get_download_info
-from src.file_utils import truncate_filename
+from src.file_utils import reserve_unique_filename, truncate_filename
 from src.general_utils import fetch_page
 from src.managers.state_manager import save_album_state
 
@@ -52,6 +52,7 @@ class AlbumDownloader:
         # round-trip.
         self.cached_items = dict(cached_items or {})
         self._state_lock = asyncio.Lock()
+        self._reserved_filenames: set[str] = set()
 
     async def execute_item_download(
         self,
@@ -92,7 +93,11 @@ class AlbumDownloader:
             item_download_link, item_filename = await get_download_info(
                 item_page,
                 item_soup,
+                self.session_info.clean_name,
             )
+
+            if self.session_info.clean_name:
+                item_filename = await self._reserve_filename_for_item(item_filename)
 
             # Download item
             if item_download_link:
@@ -200,6 +205,21 @@ class AlbumDownloader:
                 self.album_info.item_pages,
                 self.cached_items,
             )
+
+    async def _reserve_filename_for_item(self, filename: str) -> str:
+        """Reserve an unique filename for this album run.
+
+        Prevents concurrent tasks from selecting the same '(N)' candidate when
+        multiple items share the same original filename.
+        """
+        async with self._state_lock:
+            unique_filename = reserve_unique_filename(
+                self.session_info.download_path,
+                filename,
+                self._reserved_filenames,
+            )
+            self._reserved_filenames.add(unique_filename)
+            return unique_filename
 
     async def _fetch_page_with_retries(
         self,

--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -29,6 +29,7 @@ from src.config import (
 from src.file_utils import (
     matches_ignore_list,
     matches_include_list,
+    reserve_unique_filename,
     truncate_filename,
     write_on_session_log,
 )
@@ -161,6 +162,12 @@ class MediaDownloader:
             )
             self._finalize_download(SkippedReason.DOMAIN_OFFLINE)
             return False
+
+        if self.session_info.clean_name:
+            self.download_info.filename = reserve_unique_filename(
+                self.session_info.download_path,
+                self.download_info.filename,
+            )
 
         formatted_filename = truncate_filename(self.download_info.filename)
         final_path = Path(self.session_info.download_path) / formatted_filename

--- a/src/dry_run.py
+++ b/src/dry_run.py
@@ -16,7 +16,7 @@ from rich.table import Table
 from src.config import DOWNLOAD_HEADERS, KB, MAX_WORKERS
 from src.crawlers.crawler_utils import get_download_info
 from src.downloaders.download_utils import detect_range_support
-from src.file_utils import matches_ignore_list, matches_include_list, truncate_filename
+from src.file_utils import matches_ignore_list, matches_include_list, reserve_unique_filename, truncate_filename
 from src.general_utils import fetch_page
 
 if TYPE_CHECKING:
@@ -69,6 +69,8 @@ async def _resolve_item(
     session_info: SessionInfo,
     cached_items: dict[str, dict],
     semaphore: asyncio.Semaphore,
+    reserved_names: set[str],
+    reservation_lock: asyncio.Lock,
 ) -> dict:
     """Resolve filename, size and status for one item without downloading it."""
     async with semaphore:
@@ -88,9 +90,18 @@ async def _resolve_item(
         if item_soup is None:
             return {"filename": item_page, "size": None, "status": "fetch_failed"}
 
-        download_link, filename = await get_download_info(item_page, item_soup)
+        download_link, filename = await get_download_info(item_page, item_soup, session_info.clean_name)
         if not download_link:
             return {"filename": filename, "size": None, "status": "unresolved"}
+
+        if session_info.clean_name:
+            async with reservation_lock:
+                filename = reserve_unique_filename(
+                    session_info.download_path,
+                    filename,
+                    reserved_names,
+                )
+                reserved_names.add(filename)
 
         filter_status = _get_filter_status(filename, session_info.args)
         if filter_status:
@@ -144,9 +155,18 @@ async def execute_dry_run(
 ) -> None:
     """Print a preview table of what a download would do, without downloading."""
     semaphore = asyncio.Semaphore(MAX_WORKERS)
+    reserved_names: set[str] = set()
+    reservation_lock = asyncio.Lock()
     results = await asyncio.gather(
         *(
-            _resolve_item(page, session_info, cached_items, semaphore)
+            _resolve_item(
+                page,
+                session_info,
+                cached_items,
+                semaphore,
+                reserved_names,
+                reservation_lock,
+            )
             for page in item_pages
         ),
     )

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -179,6 +179,27 @@ def truncate_filename(filename: str) -> str:
     return str(filename_path.with_name(formatted_filename))
 
 
+def reserve_unique_filename(
+    download_path: str,
+    filename: str,
+    reserved_names: set[str] | None = None,
+) -> str:
+    """Pick the first available filename, using '(N)' suffixes on conflicts."""
+    directory = Path(download_path)
+    index = 0
+
+    while True:
+        candidate = _build_numbered_filename(filename, index)
+        if reserved_names and candidate in reserved_names:
+            index += 1
+            continue
+
+        if not (directory / candidate).exists():
+            return candidate
+
+        index += 1
+
+
 def matches_ignore_list(filename: str, ignore_list: list[str] | None) -> bool:
     """Return True if filename matches any word in the --ignore list."""
     return bool(ignore_list) and any(word in filename for word in ignore_list)
@@ -192,3 +213,21 @@ def matches_include_list(filename: str, include_list: list[str] | None) -> bool:
     predicates compose the same way at call sites.
     """
     return bool(include_list) and all(word not in filename for word in include_list)
+
+
+def _build_numbered_filename(filename: str, index: int) -> str:
+    """Return filename formatted as 'name (index).ext' when index > 0.
+
+    The base name is sanitized and truncated so the extension and numbering suffix
+    always fit within MAX_FILENAME_LEN.
+    """
+    filename_path = Path(filename)
+    extension = filename_path.suffix
+    base_name = remove_invalid_characters(filename_path.stem) or "file"
+    suffix = "" if index == 0 else f" ({index})"
+
+    available_len = MAX_FILENAME_LEN - len(extension) - len(suffix)
+    available_len = max(1, available_len)
+    base_name = base_name[:available_len]
+
+    return str(filename_path.with_name(f"{base_name}{suffix}{extension}"))


### PR DESCRIPTION
## **Supersedes:** #80

## Summary
This PR introduces the optional `--clean-name` CLI flag to preserve exact original filenames from Bunkr, while also fixing a false-positive bug in `format_item_filename()`.

---

### 1. Fix: False-Positive Substring Match in `format_item_filename()`
* **Issue:** Short original filenames (e.g., `1.jpg`) were accidentally discarded due to `if original_base in url_base:`. Since CDN UUIDs almost always contain matching digits like `"1"`, the function evaluated to `True` and outputted raw UUID filenames (appearing "obfuscated").
* **Fix:** Replaced the broad substring check with structured prefix matching (`url_base.startswith(f"{original_base}-")` or `_`). This ensures short filenames retain their original prefix while still preventing redundant names for genuine duplicates (e.g., `photo-123.jpg`).
* (See #80 for detailed bug reproduction and discussion)

---

### 2. Feature: `--clean-name` CLI flag
* Preserves exact original filenames found on Bunkr item pages.
* Resolves filename collisions dynamically by appending a clean numeric suffix (`(1)`, `(2)`, etc.).
* Includes a thread-safe reservation lock (`reservation_lock`) to prevent race conditions during concurrent/parallel downloads.
* Fully aligned with `--dry-run` preview execution.
* Issue Reference: #4 

---

## Usage & Testing
```bash
# Preview clean filenames
python downloader.py --dry-run --clean-name <bunkr_url>

# Download using clean filenames
python downloader.py --clean-name <bunkr_url>
```

## Comparison Preview (--dry-run):

### Standard Download (Default):

<img width="949" height="961" alt="image" src="https://github.com/user-attachments/assets/ddd8f4f9-04e8-4cd2-abc2-163894b539f9" />

### After fixing the bug:

<img width="868" height="1040" alt="image" src="https://github.com/user-attachments/assets/14e9a596-de25-4779-bebf-23bcd46845a2" />


### Clean Name Download:

<img width="494" height="1037" alt="image" src="https://github.com/user-attachments/assets/42eff38e-3c51-47ca-8628-da38e245904a" />
