### PR TITLE
Ignore existing files on disk with --clean-name

### DIFF
--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -94,7 +94,9 @@ class AlbumDownloader:
                 clean_name=self.session_info.args.clean_name,
             )
             if self.session_info.args.clean_name:
-                item_filename = await self._reserve_filename_for_item(item_filename)
+                item_filename = await self._reserve_filename_for_item(
+                    item_filename, item_page,
+                )
 
             # Download item
             if item_download_link:
@@ -202,17 +204,22 @@ class AlbumDownloader:
                 self.download_state.cached_items,
             )
 
-    async def _reserve_filename_for_item(self, filename: str) -> str:
+    async def _reserve_filename_for_item(self, filename: str, item_page: str) -> str:
         """Reserve an unique filename for this album run.
 
         Prevents concurrent tasks from selecting the same '(N)' candidate when multiple
-        items share the same original filename.
+        items share the same original filename. When a previous run already assigned a
+        name to this exact item, that name is reused, so the already-downloaded check
+        keeps matching even though items are resolved in a non-deterministic order.
         """
         async with self._state_lock:
-            unique_filename = reserve_unique_filename(
-                self.session_info.download_path,
-                filename,
-                self._reserved_filenames,
+            cached_filename = (
+                self.download_state.cached_items.get(item_page) or {}
+            ).get("filename")
+            unique_filename = (
+                cached_filename
+                if cached_filename and cached_filename not in self._reserved_filenames
+                else reserve_unique_filename(filename, self._reserved_filenames)
             )
             self._reserved_filenames.add(unique_filename)
             return unique_filename

--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -29,7 +29,6 @@ from src.config import (
 from src.file_utils import (
     matches_ignore_list,
     matches_include_list,
-    reserve_unique_filename,
     truncate_filename,
     write_on_session_log,
 )
@@ -168,12 +167,6 @@ class MediaDownloader:
             )
             self._finalize_download(SkippedReason.DOMAIN_OFFLINE)
             return False
-
-        if self.session_info.args.clean_name:
-            self.download_info.filename = reserve_unique_filename(
-                self.session_info.download_path,
-                self.download_info.filename,
-            )
 
         formatted_filename = truncate_filename(self.download_info.filename)
         final_path = Path(self.session_info.download_path) / formatted_filename

--- a/src/dry_run.py
+++ b/src/dry_run.py
@@ -110,7 +110,6 @@ async def _resolve_item(item_page: str, context: ResolveContext) -> dict:
         if context.session_info.args.clean_name:
             async with context.reservation_lock:
                 filename = reserve_unique_filename(
-                    context.session_info.download_path,
                     filename,
                     context.reserved_names,
                 )

--- a/src/file_utils.py
+++ b/src/file_utils.py
@@ -180,21 +180,23 @@ def truncate_filename(filename: str) -> str:
 
 
 def reserve_unique_filename(
-    download_path: str,
     filename: str,
     reserved_names: set[str] | None = None,
 ) -> str:
-    """Pick the first available filename, using '(N)' suffixes on conflicts."""
-    directory = Path(download_path)
+    """Pick the first filename not yet claimed in this run, using '(N)' suffixes.
+
+    Only names reserved earlier in the same run are avoided; files already on disk are
+    deliberately NOT taken into account. Numbering exists to separate distinct items of
+    the same album that share an original filename, so a given item must resolve to the
+    same name on every run -- otherwise a re-run would pick a fresh '(N)' name for an
+    item that is already downloaded and fetch it all over again. Files that already
+    exist are handled later, by the regular already-downloaded skip.
+    """
     index = 0
 
     while True:
         candidate = _build_numbered_filename(filename, index)
-        if reserved_names and candidate in reserved_names:
-            index += 1
-            continue
-
-        if not (directory / candidate).exists():
+        if not reserved_names or candidate not in reserved_names:
             return candidate
 
         index += 1


### PR DESCRIPTION
Fixes #86 

For `--clean-name`, filenames were previously resolved by scanning the download folder for the first name not already present on disk. Now, it only avoids names reserved earlier in the same run and ignores files already on disk.