### PR TITLE
Set downloaded file's modified date to match its Bunkr upload date

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -67,22 +67,26 @@ async def resolve_album_items(
     url_info: UrlInfo,
     download_path: str,
     identifier: str,
-) -> tuple[list[str], dict]:
+) -> tuple[list[str], dict, dict]:
     """Resolve album item pages, reusing cached state when available.."""
     if url_info.is_media:
-        return [url_info.url], {}
+        return [url_info.url], {}, {}
 
     cached_state = load_album_state(download_path)
     if has_cached_item_pages(cached_state, identifier):
-        return cached_state["item_pages"], cached_state["items"]
+        return (
+            cached_state["item_pages"],
+            cached_state["items"],
+            cached_state.get("item_dates", {}),
+        )
 
     host_page = get_host_page(url_info.url)
-    item_pages = await extract_all_album_item_pages(
+    item_pages, item_dates = await extract_all_album_item_pages(
         url_info.soup,
         host_page,
         url_info.url,
     )
-    return item_pages, {}
+    return item_pages, {}, item_dates
 
 
 async def get_item_pages_with_cache(
@@ -90,9 +94,9 @@ async def get_item_pages_with_cache(
     identifier: str,
     session_info: SessionInfo,
     live_manager: LiveManager,
-) -> tuple[list[str], dict]:
+) -> tuple[list[str], dict, dict]:
     """Resolve album item pages and persist newly discovered state."""
-    item_pages, cached_items = await resolve_album_items(
+    item_pages, cached_items, item_dates = await resolve_album_items(
         url_info,
         session_info.download_path,
         identifier,
@@ -103,10 +107,10 @@ async def get_item_pages_with_cache(
             event="Using cached album state",
             details=f"Reusing {num_pages} previously crawled item page(s)",
         )
-        return item_pages, cached_items
+        return item_pages, cached_items, item_dates
 
-    save_album_state(session_info.download_path, identifier, item_pages, {})
-    return item_pages, {}
+    save_album_state(session_info.download_path, identifier, item_pages, {}, item_dates)
+    return item_pages, {}, item_dates
 
 
 async def handle_download_process(
@@ -125,13 +129,15 @@ async def handle_download_process(
 
     # Album download
     if url_info.is_album:
-        item_pages, cached_items = await get_item_pages_with_cache(
+        item_pages, cached_items, item_dates = await get_item_pages_with_cache(
             url_info,
             identifier,
             session_info,
             live_manager,
         )
-        album_info = AlbumInfo(album_id=identifier, item_pages=item_pages)
+        album_info = AlbumInfo(
+            album_id=identifier, item_pages=item_pages, item_dates=item_dates,
+        )
         album_downloader = AlbumDownloader(
             session_info=session_info,
             album_info=album_info,
@@ -141,7 +147,7 @@ async def handle_download_process(
         return await album_downloader.download_album(max_retries=max_retries)
 
     # Single item download
-    download_link, filename = await get_download_info(
+    download_link, filename, item_date = await get_download_info(
         url_info.url,
         url_info.soup,
         clean_name=session_info.args.clean_name,
@@ -156,6 +162,7 @@ async def handle_download_process(
             download_link=download_link,
             filename=filename,
             task=task,
+            item_date=item_date,
         ),
         live_manager=live_manager,
         retry_config=RetryConfig(),
@@ -219,12 +226,14 @@ async def execute_dry_run_for_url(
     url_info, session_info = prepared_session
     identifier = get_identifier(url_info.url, soup=url_info.soup)
 
-    item_pages, cached_items = await resolve_album_items(
+    item_pages, cached_items, item_dates = await resolve_album_items(
         url_info,
         session_info.download_path,
         identifier,
     )
-    await execute_dry_run(identifier, item_pages, session_info, cached_items, console)
+    await execute_dry_run(
+        identifier, item_pages, session_info, cached_items, item_dates, console,
+    )
 
 
 async def validate_and_download(

--- a/src/config.py
+++ b/src/config.py
@@ -10,6 +10,7 @@ import logging
 import re
 from collections import deque
 from dataclasses import dataclass, field
+from datetime import datetime
 from enum import IntEnum
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -174,6 +175,7 @@ class AlbumInfo:
 
     album_id: str
     item_pages: list[str]
+    item_dates: dict[str, datetime | None] = field(default_factory=dict)
 
 @dataclass
 class DownloadInfo:
@@ -183,6 +185,7 @@ class DownloadInfo:
     download_link: str
     filename: str
     task: int
+    item_date: datetime | None = None
 
 @dataclass
 class SessionInfo:
@@ -231,6 +234,7 @@ class ResolveContext:
 
     session_info: SessionInfo
     cached_items: dict[str, dict]
+    item_dates: dict[str, datetime | None]
     semaphore: asyncio.Semaphore
     reserved_names: set[str]
     reservation_lock: asyncio.Lock

--- a/src/crawlers/crawler_utils.py
+++ b/src/crawlers/crawler_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 
 import aiohttp
@@ -58,12 +59,25 @@ def extract_item_pages(soup: BeautifulSoup, host_page: str) -> list[str] | None:
         return None
 
 
+def extract_item_dates(soup: BeautifulSoup) -> list[datetime | None]:
+    """Extract each item's date from an album listing page, in document order.
+
+    Bunkr's album grid shows a small pill per item with class "theDate"
+    containing the item's date, e.g. "04:42:44 27/09/2023" (HH:MM:SS DD/MM/YYYY).
+    This list is meant to be paired positionally (via zip) with the item hrefs
+    returned by extract_item_pages(), since both are extracted from the same
+    album listing page in the same document order.
+    """
+    date_tags = soup.find_all(class_="theDate")
+    return [_parse_date_string(tag.get_text(strip=True)) for tag in date_tags]
+
+
 async def extract_all_album_item_pages(
     initial_soup: BeautifulSoup,
     host_page: str,
     url: str,
-) -> list[str]:
-    """Collect item page links from an album, including pagination."""
+) -> tuple[list[str], dict[str, datetime | None]]:
+    """Collect item page links (and their dates) from an album, incl. pagination."""
     if initial_soup is None:
         error_message = f"Failed to parse album landing page: {url}"
         raise RuntimeError(error_message)
@@ -73,6 +87,10 @@ async def extract_all_album_item_pages(
     if item_pages is None:
         error_message = f"Unable to extract album items from {url}"
         raise RuntimeError(error_message)
+
+    item_dates: dict[str, datetime | None] = dict(
+        zip(item_pages, extract_item_dates(initial_soup), strict=False),
+    )
 
     next_album_pages = extract_next_album_pages(initial_soup, url)
     if next_album_pages is not None:
@@ -85,8 +103,11 @@ async def extract_all_album_item_pages(
 
             next_item_pages = extract_item_pages(next_page_soup, host_page)
             item_pages.extend(next_item_pages)
+            item_dates.update(
+                zip(next_item_pages, extract_item_dates(next_page_soup), strict=False),
+            )
 
-    return item_pages
+    return item_pages, item_dates
 
 
 async def get_item_download_link(
@@ -111,6 +132,74 @@ def decrypt_cf_email(cf_email_hex: str) -> str:
     key = raw_bytes[0]
     decrypted_bytes = bytes(byte ^ key for byte in raw_bytes[1:])
     return decrypted_bytes.decode("utf-8")
+
+
+_DATE_FORMATS = (
+    "%Y-%m-%dT%H:%M:%S",
+    "%Y-%m-%d %H:%M:%S",
+    "%Y-%m-%d",
+    "%d/%m/%Y",
+    "%B %d, %Y",
+    "%b %d, %Y",
+    "%H:%M:%S %d/%m/%Y",
+)
+
+
+def _parse_date_string(text: str) -> datetime | None:
+    """Best-effort parse of a date string into an aware UTC datetime."""
+    text = text.strip()
+    if not text:
+        return None
+
+    # ISO 8601, e.g. "2024-03-15T10:22:03Z" or with a numeric UTC offset.
+    try:
+        iso_text = text[:-1] + "+00:00" if text.endswith("Z") else text
+        parsed = datetime.fromisoformat(iso_text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except ValueError:
+        pass
+
+    for fmt in _DATE_FORMATS:
+        try:
+            parsed = datetime.strptime(text, fmt)
+            return parsed.replace(tzinfo=timezone.utc)
+        except ValueError:
+            continue
+
+    return None
+
+
+def get_item_date(item_soup: BeautifulSoup) -> datetime | None:
+    """Extract the item's upload/creation date from the item page, if present.
+
+    NOTE: The exact markup Bunkr uses to expose an item's date has not been
+    confirmed against a live page in this environment (no network access to
+    bunkr.* domains here). This tries a few common patterns, in order of
+    reliability, and returns None (no mtime is set) if none match rather than
+    guessing wrong. Once confirmed against real HTML (see debug_item_date.py),
+    this function should be tightened to the actual selector.
+    """
+    # 1) Standard HTML5 <time datetime="..."> tag -- machine-readable, most
+    #    reliable if present.
+    time_tag = item_soup.find("time")
+    if time_tag and time_tag.get("datetime"):
+        parsed = _parse_date_string(time_tag["datetime"])
+        if parsed:
+            return parsed
+
+    # 2) A tag whose visible text looks like a relative date ("... ago") and
+    #    which carries the exact date in its `title` tooltip attribute -- a
+    #    common pattern for these Bunkr-family frontends.
+    for tag in item_soup.find_all(attrs={"title": True}):
+        text = tag.get_text(strip=True)
+        if re.search(r"\bago\b|\byesterday\b|\btoday\b", text, re.IGNORECASE):
+            parsed = _parse_date_string(tag["title"])
+            if parsed:
+                return parsed
+
+    return None
 
 
 def get_item_filename(item_soup: BeautifulSoup) -> str:
@@ -169,7 +258,7 @@ async def get_download_info(
     *,
     clean_name: bool,
 ) -> tuple:
-    """Gather download information (link and filename) for the item."""
+    """Gather download information (link, filename and date) for the item."""
     async with aiohttp.ClientSession() as session:
         item_download_link = await get_item_download_link(
             session,
@@ -177,9 +266,10 @@ async def get_download_info(
             soup=item_soup,
         )
 
+    item_date = get_item_date(item_soup)
     item_filename = get_item_filename(item_soup)
     if clean_name:
-        return item_download_link, item_filename
+        return item_download_link, item_filename, item_date
 
     url_based_filename = (
         get_url_based_filename(item_download_link) if item_download_link else None
@@ -189,4 +279,4 @@ async def get_download_info(
         if url_based_filename
         else item_filename
     )
-    return item_download_link, formatted_item_filename
+    return item_download_link, formatted_item_filename, item_date

--- a/src/downloaders/album_downloader.py
+++ b/src/downloaders/album_downloader.py
@@ -29,6 +29,8 @@ from src.managers.state_manager import save_album_state
 from .media_downloader import MediaDownloader
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from src.managers.live_manager import LiveManager
 
 _FETCH_BASE_DELAY = 1.5
@@ -72,8 +74,8 @@ class AlbumDownloader:
             task = self.live_manager.add_task(current_task=current_task)
 
             # Process the download of an item
-            item_download_link, item_filename = await self._resolve_item_download(
-                item_page,
+            item_download_link, item_filename, item_date = (
+                await self._resolve_item_download(item_page)
             )
             if item_download_link:
                 await self._download_item(
@@ -82,6 +84,7 @@ class AlbumDownloader:
                     item_download_link,
                     task,
                     max_retries,
+                    item_date,
                 )
 
             else:
@@ -160,10 +163,12 @@ class AlbumDownloader:
         self.live_manager.update_summary(SkippedReason.ALREADY_DOWNLOADED)
         return True
 
-    async def _resolve_item_download(self, item_page: str) -> tuple[str, str]:
-        """Resolve the download URL and filename for an item page."""
+    async def _resolve_item_download(
+        self, item_page: str,
+    ) -> tuple[str, str, datetime | None]:
+        """Resolve the download URL, filename and date for an item page."""
         item_soup = await self._fetch_page_with_retries(item_page)
-        item_download_link, item_filename = await get_download_info(
+        item_download_link, item_filename, page_item_date = await get_download_info(
             item_page,
             item_soup,
             clean_name=self.session_info.args.clean_name,
@@ -174,7 +179,11 @@ class AlbumDownloader:
                 item_page,
             )
 
-        return item_download_link, item_filename
+        # Prefer the date read from the album listing page (confirmed reliable);
+        # fall back to whatever get_download_info found on the item's own page.
+        item_date = self.album_info.item_dates.get(item_page) or page_item_date
+
+        return item_download_link, item_filename, item_date
 
     async def _download_item(
         self,
@@ -183,6 +192,7 @@ class AlbumDownloader:
         item_download_link: str,
         task: int,
         max_retries: int,
+        item_date: datetime | None = None,
     ) -> None:
         """Download an item and persist its resulting download state."""
         download_info = DownloadInfo(
@@ -190,6 +200,7 @@ class AlbumDownloader:
             download_link=item_download_link,
             filename=item_filename,
             task=task,
+            item_date=item_date,
         )
         retry_confing = RetryConfig(retries=max_retries, has_external_retry=True)
         media_downloader = MediaDownloader(
@@ -206,6 +217,7 @@ class AlbumDownloader:
                 "filename": item_filename,
                 "download_link": item_download_link,
                 "item_url": item_page,
+                "item_date": item_date,
             })
 
         await self._persist_item_state(
@@ -241,6 +253,7 @@ class AlbumDownloader:
                 self.album_info.album_id,
                 self.album_info.item_pages,
                 self.download_state.cached_items,
+                self.album_info.item_dates,
             )
 
     async def _reserve_filename_for_item(self, filename: str, item_page: str) -> str:
@@ -319,6 +332,7 @@ class AlbumDownloader:
                 download_link=data["download_link"],
                 filename=data["filename"],
                 task=data["id"],
+                item_date=data.get("item_date"),
             )
             failed_again = await self._retry_failed_download(failed_download_info)
             if failed_again:

--- a/src/downloaders/media_downloader.py
+++ b/src/downloaders/media_downloader.py
@@ -6,6 +6,8 @@ download experience.
 
 from __future__ import annotations
 
+import logging
+import os
 import random
 import time
 from pathlib import Path
@@ -193,6 +195,7 @@ class MediaDownloader:
         if failed_download:
             return self._handle_failed_download(is_final_attempt=is_final_attempt)
 
+        self._apply_item_mtime(final_path)
         self.live_manager.update_summary(CompletedReason.DOWNLOAD_SUCCESS)
         return False
 
@@ -343,6 +346,27 @@ class MediaDownloader:
         )
         self._finalize_download(FailedReason.MAX_RETRIES_REACHED)
         return True
+
+    def _apply_item_mtime(self, final_path: Path) -> None:
+        """Set the downloaded file's modified time to the item's source date.
+
+        Best-effort only: if no date could be extracted from the item page
+        (self.download_info.item_date is None) or the OS call fails, the file
+        simply keeps its normal (download-time) mtime -- this never affects
+        whether the download counts as successful.
+        """
+        item_date = self.download_info.item_date
+        if item_date is None:
+            return
+
+        try:
+            timestamp = item_date.timestamp()
+            os.utime(final_path, (timestamp, timestamp))
+
+        except (OSError, OverflowError, ValueError):
+            logging.warning(
+                "Could not set modified date for %s", self.download_info.filename,
+            )
 
     def _finalize_download(
         self,

--- a/src/dry_run.py
+++ b/src/dry_run.py
@@ -101,7 +101,7 @@ async def _resolve_item(item_page: str, context: ResolveContext) -> dict:
         if item_soup is None:
             return {"filename": item_page, "size": None, "status": "fetch_failed"}
 
-        download_link, filename = await get_download_info(
+        download_link, filename, _item_date = await get_download_info(
             item_page, item_soup, clean_name=context.session_info.args.clean_name,
         )
         if not download_link:
@@ -165,6 +165,7 @@ async def execute_dry_run(
     item_pages: list[str],
     session_info: SessionInfo,
     cached_items: dict[str, dict],
+    item_dates: dict[str, object],
     console: Console,
 ) -> None:
     """Print a preview table of what a download would do, without downloading."""
@@ -174,6 +175,7 @@ async def execute_dry_run(
     context = ResolveContext(
         session_info=session_info,
         cached_items=cached_items,
+        item_dates=item_dates,
         semaphore=semaphore,
         reserved_names=reserved_names,
         reservation_lock=reservation_lock,

--- a/src/managers/state_manager.py
+++ b/src/managers/state_manager.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
 
 from src.config import STATE_FILE
@@ -44,6 +45,17 @@ def load_album_state(download_path: str) -> dict | None:
 
     data.setdefault("item_pages", [])
     data.setdefault("items", {})
+
+    item_dates = {}
+    for item_url, iso_date in data.get("item_dates", {}).items():
+        if not iso_date:
+            continue
+        try:
+            item_dates[item_url] = datetime.fromisoformat(iso_date)
+        except ValueError:
+            continue
+    data["item_dates"] = item_dates
+
     return data
 
 
@@ -52,15 +64,24 @@ def save_album_state(
     album_id: str,
     item_pages: list[str],
     items: dict[str, dict],
+    item_dates: dict[str, datetime | None] | None = None,
 ) -> None:
     """Persist the full album state, overwriting any previous file."""
     path = _state_path(download_path)
+    serialized_dates = {
+        item_url: date.isoformat()
+        for item_url, date in (item_dates or {}).items()
+        if date is not None
+    }
 
     try:
         path.write_text(
-            json.dumps(
-                {"album_id": album_id, "item_pages": item_pages, "items": items},
-            ),
+            json.dumps({
+                "album_id": album_id,
+                "item_pages": item_pages,
+                "items": items,
+                "item_dates": serialized_dates,
+            }),
             encoding="utf-8",
         )
 


### PR DESCRIPTION
## Summary

Adds an enhancement where, when downloading items from an album, the
file's modified date on disk is set to the date shown for that item on
Bunkr, instead of defaulting to the local download time. https://github.com/Lysagxra/BunkrDownloader/issues/85

## Details

- Each item's date is read from the album listing page (the ".theDate"
  pill shown next to every item, e.g. "04:42:44 27/09/2023") while
  crawling the album, and carried through the pipeline alongside the
  existing item_pages/cached_items plumbing.
- For direct single-item links (no album listing page available), a
  best-effort fallback checks the item's own page for a <time> tag or a
  title="" tooltip attribute on relative-date text.
- Dates are persisted in the per-album state cache file, so they're
  still available on a resumed/cached run without re-crawling.
- Setting the mtime is best-effort and non-fatal: if no date can be
  found, or the os.utime() call fails for any reason, the file simply
  keeps its normal download-time mtime. This never affects whether a
  download counts as successful.

## Testing

Verified with synthetic end-to-end simulations (no live network access
in the dev environment used):
- Album with multiple items: each downloaded file's mtime matched its
  own item date exactly.
- Single-item (non-album) download: falls back correctly, no crash
  when no date is found.
- Dry-run preview: unaffected, no regression.
- All changed files pass `py_compile` and `ruff check --select F,E`.
